### PR TITLE
Move to Quay

### DIFF
--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -97,6 +97,3 @@ RUN apt-get install sudo
 
 RUN pip install awscli boto3 sa-rpm-s3
 RUN apt-get install -y libkrb5-dev unixodbc-dev rpm python-deltarpm createrepo yum-utils bison
-
-
-

--- a/README.md
+++ b/README.md
@@ -70,24 +70,24 @@ To install the official release:
     $ wget -qO- https://stackstate-agent-2.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" bash
 
 ##### Test
-    
+
 If you wanna install a branch version use the test repository:
 
     $ curl -o- https://stackstate-agent-2-test.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="PR_NAME" bash
      or
     $ wget -qO- https://stackstate-agent-2-test.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="PR_NAME" bash
 
-and replace `PR_NAME` with the branch name (e.g. `master`, `STAC-xxxx`). 
+and replace `PR_NAME` with the branch name (e.g. `master`, `STAC-xxxx`).
 
 ### Docker
 
 ##### Official
 
-    $ docker pull stackstate/stackstate-agent-2:latest
+    $ docker pull docker.io/stackstate/stackstate-agent-2:latest
 
 ##### Test
 
-    $ docker pull stackstate/stackstate-agent-2-test:latest
+    $ docker pull docker.io/stackstate/stackstate-agent-2-test:latest
 
 ### Windows
 
@@ -98,12 +98,12 @@ To install the official release:
     $ . { iwr -useb https://stackstate-agent-2.s3.amazonaws.com/install.ps1 } | iex; install -stsApiKey "xxx" -stsUrl "yyy"
 
 ##### Test
-    
+
 If you wanna install a branch version use the test repository:
 
     $ . { iwr -useb https://stackstate-agent-2-test.s3.amazonaws.com/install.ps1 } | iex; install -stsApiKey "xxx" -stsUrl "yyy" -codeName "PR_NAME"
 
-and replace `PR_NAME` with the branch name (e.g. `master`, `STAC-xxxx`). 
+and replace `PR_NAME` with the branch name (e.g. `master`, `STAC-xxxx`).
 
 #### Arguments
 

--- a/deployment/kubernetes/agent.yaml
+++ b/deployment/kubernetes/agent.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: stackstate-agent
       containers:
-      - image: stackstate/stackstate-agent-2-test:master
+      - image: quay.io./stackstate/stackstate-agent-2-test:master
         imagePullPolicy: Always
         name: stackstate-agent
         ports:

--- a/deployment/kubernetes/cluster-agent.yaml
+++ b/deployment/kubernetes/cluster-agent.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: stackstate-cluster-agent
       containers:
-      - image: stackstate/stackstate-cluster-agent-test:master
+      - image: quay.io./stackstate/stackstate-cluster-agent-test:master
         imagePullPolicy: Always
         name: stackstate-cluster-agent
         env:

--- a/deployment/kubernetes/demo-app/java-db-demo.yaml
+++ b/deployment/kubernetes/demo-app/java-db-demo.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: db
-          image: 508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:db-master
+          image: quay.io/stackstate/stackstate-trace-java-demo:db-master
           env:
           - name: POSTGRES_USER
             value: 'app'
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
         - name: books-app
-          image: 508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:books-app-master
+          image: quay.io/stackstate/stackstate-trace-java-demo:books-app-master
           ports:
             - containerPort: 8081
               name: books-app
@@ -117,7 +117,7 @@ spec:
     spec:
       containers:
         - name: authors-app
-          image: 508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:authors-app-master
+          image: quay.io/stackstate/stackstate-trace-java-demo:authors-app-master
           ports:
             - containerPort: 8081
               name: authors-app

--- a/omnibus/package-scripts/Readme.md
+++ b/omnibus/package-scripts/Readme.md
@@ -1,15 +1,27 @@
-Getting repo up
+The order in which these script are executed varies between APT and YUM which can
+lead to some rather sneaky bugs. Here's the standard order for updates.
 
-/etc/yum.repos.d/myrepo.repo
+# APT
+## source https://debian-handbook.info/browse/stable/sect.package-meta-information.html
 
-[myrepo]
-name=This is my repo
-baseurl=https://repobase/master
-enabled=1
-gpgcheck=0
+ * `prerm` script of the old package (with arguments: `upgrade <new-version>`)
+ * `preinst` script of the new package (with arguments: `upgrade <old-version>`)
+ * New files get unpacked based on the file list embedded in the `.deb` package
+ * `postrm` script from the old package (with arguments `upgrade <new-version>`)
+ * `dpkg` updates the files list, removes the files that don't exist anymore, etc.
+ * `postinst` of the new script is run (with arguments `configure <lst-configured-version>`
 
-yum makecache --disablerepo=* --enablerepo=myrepo
+# YUM
+## source: https://fedoraproject.org/wiki/Packaging:Scriptlets
 
-Checking packages in repo
+ * `pretrans` of new package
+ * `preinst` of new package
+ * Files in the list get copied
+ * `postinst` of new package
+ * `prerm` of old package
+ * Files in the old package file list that are not in the new one's get removed
+ * `postrm` of the old package gets run
+ * `posttrans` of the _new_ package is run
 
-yum --disablerepo="*" --enablerepo="myrepo" list available
+**Note:** if you remove files or other components in the `postrm` script, updates
+won't work as expected with YUM.

--- a/omnibus/package-scripts/publish_image.sh
+++ b/omnibus/package-scripts/publish_image.sh
@@ -2,21 +2,22 @@
 
 set -xe
 
-IMAGE_TAG=$1
-IMAGE_REPO=$2
-DOCKERFILE_PATH=$3
+IMAGE_TAG="${1}"
+IMAGE_REPO="${2}"
+DOCKERFILE_PATH="${3}"
 PUSH_LATEST="${4:-false}"
+REGISTRY="${5:-docker.io}"
 
-echo $IMAGE_TAG
-echo $IMAGE_REPO
-echo $DOCKERFILE_PATH
+echo "${IMAGE_TAG}"
+echo "${IMAGE_REPO}"
+echo "${DOCKERFILE_PATH}"
 
-docker build -t stackstate/${IMAGE_REPO}:${IMAGE_TAG} $DOCKERFILE_PATH
-docker login -u $DOCKER_USER -p $DOCKER_PASS
-docker push stackstate/${IMAGE_REPO}:${IMAGE_TAG}
+docker build -t "${REGISTRY}/stackstate/${IMAGE_REPO}:${IMAGE_TAG}" "${DOCKERFILE_PATH}"
+docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
+docker push "${REGISTRY}/stackstate/${IMAGE_REPO}:${IMAGE_TAG}"
 
 if [ "$PUSH_LATEST" = "true" ]; then
-    docker tag stackstate/${IMAGE_REPO}:${IMAGE_TAG} stackstate/${IMAGE_REPO}:latest
+    docker tag "${REGISTRY}/stackstate/${IMAGE_REPO}:${IMAGE_TAG}" "${REGISTRY}/stackstate/${IMAGE_REPO}:latest"
     echo 'Pushing release to latest'
-    docker push stackstate/${IMAGE_REPO}:latest
+    docker push "${REGISTRY}/stackstate/${IMAGE_REPO}:latest"
 fi

--- a/test/molecule-role/molecule/compose/files/docker-compose.yml
+++ b/test/molecule-role/molecule/compose/files/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       ADVERTISED_HOST: kafka
       ADVERTISED_PORT: 9092
   receiver:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-receiver:master"
+    image: "quay.io/stackstate/stackstate-receiver:master"
     command: "-J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     ports:
       - 7077:7077
@@ -18,7 +18,7 @@ services:
       KAFKA_BROKERS: kafka:9092
     mem_limit: 1G
   correlate:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-correlate:master"
+    image: "quay.io/stackstate/stackstate-correlate:master"
     entrypoint: "bin/stackstate-correlate -J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     depends_on:
       - receiver
@@ -26,7 +26,7 @@ services:
       KAFKA_BROKERS: kafka:9092
     mem_limit: 1G
   topic-api:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-topic-api:master"
+    image: "quay.io/stackstate/stackstate-topic-api:master"
     command: "-J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     ports:
       - 7070:7070
@@ -37,7 +37,7 @@ services:
       ZOOKEEPER_QUORUM: kafka
     mem_limit: 1G
   db:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:db-master"
+    image: "quay.io/stackstate/stackstate-trace-java-demo:db-master"
     environment:
       POSTGRES_USER: 'app'
       POSTGRES_PASSWORD: 'app'
@@ -53,7 +53,7 @@ services:
       - "traefik.frontend.rule=Host:stackstate-demo-db.docker.localhost"
       - "traefik.backend=stackstate-demo-db"
   stackstate-books-app:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:books-app-master"
+    image: "quay.io/stackstate/stackstate-trace-java-demo:books-app-master"
     ports:
       - '8081-8091:8081'
     depends_on:
@@ -65,7 +65,7 @@ services:
     environment:
       MAVEN_OPTS: "-Dsts.service.name=stackstate-books-app -Dsts.agent.host=${DOCKER_HOST_IP} -Dsts.agent.port=8126 -Dstackstate.slf4j.simpleLogger.defaultLogLevel=debug -javaagent:/sts-java-agent.jar"
   stackstate-authors-app:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-trace-java-demo:authors-app-master"
+    image: "quay.io/stackstate/stackstate-trace-java-demo:authors-app-master"
     ports:
       - '8092-8099:8081'
     depends_on:
@@ -88,7 +88,7 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
   stackstate-agent:
-    image: stackstate/stackstate-agent-2-test:${AGENT_VERSION}
+    image: quay.io./stackstate/stackstate-agent-2-test:${AGENT_VERSION}
     network_mode: "host"
     pid: "host"
     privileged: true

--- a/test/molecule-role/molecule/vms/files/receiver/docker-compose.yml
+++ b/test/molecule-role/molecule/vms/files/receiver/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       ADVERTISED_HOST: kafka
       ADVERTISED_PORT: 9092
   receiver:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-receiver:master"
+    image: "quay.io/stackstate/stackstate-receiver:master"
     command: "-J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     ports:
       - 7077:7077
@@ -18,7 +18,7 @@ services:
       KAFKA_BROKERS: kafka:9092
     mem_limit: 1G
   correlate:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-correlate:master"
+    image: "quay.io/stackstate/stackstate-correlate:master"
     entrypoint: "bin/stackstate-correlate -J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     depends_on:
       - receiver
@@ -26,7 +26,7 @@ services:
       KAFKA_BROKERS: kafka:9092
     mem_limit: 1G
   topic-api:
-    image: "508573134510.dkr.ecr.eu-west-1.amazonaws.com/stackstate-topic-api:master"
+    image: "quay.io/stackstate/stackstate-topic-api:master"
     command: "-J-Xms128M -J-Xmx1G -J-XX:+ExitOnOutOfMemoryError -DconsoleLogging=true -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1"
     ports:
       - 7070:7070


### PR DESCRIPTION
### What does this PR do?

Moves all *private* repositories (Amazon ECR, and anything on DockerHub that contains private code) to Quay.io

### Motivation

1. @lowdewijk and I decided to start using Quay for private images because Quay supports issuing tokens for so-called "robot accounts", which allows us to assign customers access to our repositories without them having to create user accounts themselves.

2. Amazon ECR is a nightmare => https://nick.sarbicki.com/blog/ecr-is-a-nightmare/

### Additional Notes

Anything else we should know when reviewing?

Any Docker image that's a CI runner (`gitlab` or `circleci`), or anything else that's a public repository on our DockerHub I did not change for moving to Quay since it's currently public on our DockerHub currently. If I missed a *private* image that should go on Quay.io, let me know.