### PR TITLE
feature(openshift) [STAC-5847] Check cluster type (k8s/os) at start. …

### DIFF
--- a/pkg/collector/corechecks/cluster/kubeapi/kubernetes_topology.go
+++ b/pkg/collector/corechecks/cluster/kubeapi/kubernetes_topology.go
@@ -480,10 +480,8 @@ func containerToPodStackStateRelation(containerExternalID, podExternalID string)
 func (t *TopologyCheck) serviceToStackStateComponent(service v1.Service, endpoints []EndpointID) topology.Component {
 	log.Tracef("Mapping kubernetes pod service to StackState component: %s", service.String())
 	// create identifier list to merge with StackState components
+	var identifiers []string
 	serviceID := buildServiceID(service.Namespace, service.Name)
-	identifiers := []string{
-		fmt.Sprintf("urn:service:/%s", serviceID),
-	}
 
 	// all external ip's which are associated with this service, but are not managed by kubernetes
 	for _, ip := range service.Spec.ExternalIPs {
@@ -494,14 +492,14 @@ func (t *TopologyCheck) serviceToStackStateComponent(service v1.Service, endpoin
 
 	// all endpoints for this service
 	for _, endpoint := range endpoints {
-		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", serviceID, endpoint.URL))
+		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", t.instance.ClusterName, endpoint.URL))
 	}
 
 	switch service.Spec.Type {
 	case v1.ServiceTypeClusterIP:
-		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", serviceID, service.Spec.ClusterIP))
+		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", t.instance.ClusterName, service.Spec.ClusterIP))
 	case v1.ServiceTypeLoadBalancer:
-		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", serviceID, service.Spec.LoadBalancerIP))
+		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", t.instance.ClusterName, service.Spec.LoadBalancerIP))
 	default:
 	}
 

--- a/stackstate-release.md
+++ b/stackstate-release.md
@@ -4,7 +4,8 @@
 
 **Features**
 
-- Enable new cluster agent _[(STAC-5008)](https://stackstate.atlassian.net/browse/STAC-5008)_
+- Make cluster agent gather OpenShift topology _[(STAC-5847)](https://stackstate.atlassian.net/browse/STAC-5847)_
+- Enable new cluster agent to gather Kubernetes topology _[(STAC-5008)](https://stackstate.atlassian.net/browse/STAC-5008)_
 
 ## 2.0.4 (2019-08-26)
 


### PR DESCRIPTION
…Use correct topology and components types based on cluster type. Safely use k8s entity labels

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
