### PR TITLE
STAC-11523 K8s ExternalName Service type

### DIFF
--- a/deployment/kubernetes/test_workloads/external-service.yaml
+++ b/deployment/kubernetes/test_workloads/external-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: google-service
+spec:
+  type: ExternalName
+  externalName: google.com
+  ports:
+  - port: 80
+    targetPort: 80

--- a/pkg/collector/corechecks/cluster/dns/dns.go
+++ b/pkg/collector/corechecks/cluster/dns/dns.go
@@ -1,0 +1,7 @@
+package dns
+
+import "net"
+
+type DNSResolver func(name string) ([]string, error)
+
+var _ DNSResolver = net.LookupHost // Compile-time check

--- a/pkg/collector/corechecks/cluster/dns/dns.go
+++ b/pkg/collector/corechecks/cluster/dns/dns.go
@@ -2,6 +2,10 @@ package dns
 
 import "net"
 
-type DNSResolver func(name string) ([]string, error)
+// Resolver abstracts away the system dependency on the net.LookupHost, allowing it to be mocked out in testing.
+type Resolver func(name string) ([]string, error)
 
-var _ DNSResolver = net.LookupHost // Compile-time check
+// StandardResolver is the default net.LookupHost DNS resolver
+var StandardResolver = net.LookupHost
+
+var _ Resolver = StandardResolver // Compile-time check

--- a/pkg/collector/corechecks/cluster/topologycollectors/common.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/common.go
@@ -4,6 +4,7 @@ package topologycollectors
 
 import (
 	"fmt"
+
 	"github.com/StackVista/stackstate-agent/pkg/collector/corechecks/cluster/urn"
 	"github.com/StackVista/stackstate-agent/pkg/topology"
 	"github.com/StackVista/stackstate-agent/pkg/util/kubernetes/apiserver"
@@ -192,7 +193,9 @@ func (c *clusterTopologyCommon) buildEndpointExternalID(endpointID string) strin
 func (c *clusterTopologyCommon) initTags(meta metav1.ObjectMeta) map[string]string {
 	tags := make(map[string]string, 0)
 	if meta.Labels != nil {
-		tags = meta.Labels
+		for k, v := range meta.Labels {
+			tags[k] = v
+		}
 	}
 
 	// set the cluster name and the namespace

--- a/pkg/collector/corechecks/cluster/topologycollectors/common.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/common.go
@@ -15,6 +15,7 @@ type ClusterTopologyCommon interface {
 	GetAPIClient() apiserver.APICollectorClient
 	GetInstance() topology.Instance
 	GetName() string
+	GetURNBuilder() urn.Builder
 	CreateRelation(sourceExternalID, targetExternalID, typeName string) *topology.Relation
 	CreateRelationData(sourceExternalID, targetExternalID, typeName string, data map[string]interface{}) *topology.Relation
 	initTags(meta metav1.ObjectMeta) map[string]string
@@ -65,6 +66,11 @@ func (c *clusterTopologyCommon) GetInstance() topology.Instance {
 // GetAPIClient
 func (c *clusterTopologyCommon) GetAPIClient() apiserver.APICollectorClient {
 	return c.APICollectorClient
+}
+
+// GetURNBuilder
+func (c *clusterTopologyCommon) GetURNBuilder() urn.Builder {
+	return c.urn
 }
 
 // CreateRelationData creates a StackState relation called typeName for the given sourceExternalID and targetExternalID

--- a/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
@@ -165,7 +165,7 @@ func (sc *ServiceCollector) serviceToStackStateComponent(service v1.Service) *to
 			for _, port := range service.Spec.Ports {
 				// map all the node ports
 				if port.NodePort != 0 {
-					identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s:%d", sc.GetInstance().URL, service.Spec.ClusterIP, port.NodePort))
+					identifiers = append(identifiers, sc.buildEndpointExternalID(fmt.Sprintf("%s:%d", service.Spec.ClusterIP, port.NodePort)))
 				}
 			}
 		}
@@ -202,6 +202,7 @@ func (sc *ServiceCollector) serviceToStackStateComponent(service v1.Service) *to
 	serviceExternalID := sc.buildServiceExternalID(service.Namespace, service.Name)
 
 	tags := sc.initTags(service.ObjectMeta)
+	tags["service-type"] = string(service.Spec.Type)
 
 	if service.Spec.ClusterIP == "None" {
 		tags["service"] = "headless"
@@ -238,7 +239,7 @@ func (sc *ServiceCollector) serviceToExternalServiceComponent(service v1.Service
 		for _, port := range service.Spec.Ports {
 			// map all the node ports
 			if port.Port != 0 {
-				identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s:%d", sc.GetInstance().URL, service.Spec.ExternalName, port.Port))
+				identifiers = append(identifiers, sc.buildEndpointExternalID(fmt.Sprintf("%s:%d", service.Spec.ExternalName, port.Port)))
 			}
 		}
 
@@ -252,7 +253,7 @@ func (sc *ServiceCollector) serviceToExternalServiceComponent(service v1.Service
 				for _, port := range service.Spec.Ports {
 					// map all the node ports
 					if port.Port != 0 {
-						identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s:%d", sc.GetInstance().URL, addr, port.Port))
+						identifiers = append(identifiers, sc.buildEndpointExternalID(fmt.Sprintf("%s:%d", addr, port.Port)))
 					}
 				}
 			}
@@ -265,7 +266,7 @@ func (sc *ServiceCollector) serviceToExternalServiceComponent(service v1.Service
 
 	log.Tracef("Created identifiers for %s: %v", service.Name, identifiers)
 
-	externalID := fmt.Sprintf("%s:%s:external-service/%s", sc.GetURNBuilder().URNPrefix(), service.Namespace, service.Name)
+	externalID := sc.GetURNBuilder().BuildComponentExternalID("external-service", service.Namespace, service.Name)
 
 	tags := sc.initTags(service.ObjectMeta)
 

--- a/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
@@ -4,7 +4,6 @@ package topologycollectors
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/StackVista/stackstate-agent/pkg/collector/corechecks/cluster/dns"
 	"github.com/StackVista/stackstate-agent/pkg/topology"
@@ -17,7 +16,7 @@ type ServiceCollector struct {
 	ComponentChan chan<- *topology.Component
 	RelationChan  chan<- *topology.Relation
 	ClusterTopologyCollector
-	DNS dns.DNSResolver
+	DNS dns.Resolver
 }
 
 // EndpointID contains the definition of a cluster ip
@@ -33,7 +32,7 @@ func NewServiceCollector(componentChannel chan<- *topology.Component, relationCh
 		ComponentChan:            componentChannel,
 		RelationChan:             relationChannel,
 		ClusterTopologyCollector: clusterTopologyCollector,
-		DNS:                      net.LookupHost,
+		DNS:                      dns.StandardResolver,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/service_collector.go
@@ -4,9 +4,12 @@ package topologycollectors
 
 import (
 	"fmt"
+	"net"
+
+	"github.com/StackVista/stackstate-agent/pkg/collector/corechecks/cluster/dns"
 	"github.com/StackVista/stackstate-agent/pkg/topology"
 	"github.com/StackVista/stackstate-agent/pkg/util/log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ServiceCollector implements the ClusterTopologyCollector interface.
@@ -14,6 +17,7 @@ type ServiceCollector struct {
 	ComponentChan chan<- *topology.Component
 	RelationChan  chan<- *topology.Relation
 	ClusterTopologyCollector
+	DNS dns.DNSResolver
 }
 
 // EndpointID contains the definition of a cluster ip
@@ -29,6 +33,7 @@ func NewServiceCollector(componentChannel chan<- *topology.Component, relationCh
 		ComponentChan:            componentChannel,
 		RelationChan:             relationChannel,
 		ClusterTopologyCollector: clusterTopologyCollector,
+		DNS:                      net.LookupHost,
 	}
 }
 
@@ -90,6 +95,16 @@ func (sc *ServiceCollector) CollectorFunction() error {
 		component := sc.serviceToStackStateComponent(service)
 
 		sc.ComponentChan <- component
+
+		// Check whether we have an ExternalName service, which will result in an extra component+relation
+		if service.Spec.Type == v1.ServiceTypeExternalName {
+			externalService := sc.serviceToExternalServiceComponent(service)
+
+			sc.ComponentChan <- externalService
+			sc.RelationChan <- sc.serviceToExternalServiceStackStateRelation(component.ExternalID, externalService.ExternalID)
+		}
+
+		// First ensure we publish all components, else the test becomes complex
 		sc.RelationChan <- sc.namespaceToServiceStackStateRelation(sc.buildNamespaceExternalID(service.Namespace), component.ExternalID)
 
 		publishedPodRelations := make(map[string]string, 0)
@@ -141,12 +156,12 @@ func (sc *ServiceCollector) serviceToStackStateComponent(service v1.Service) *to
 	case v1.ServiceTypeClusterIP:
 		// verify that the cluster ip is not empty
 		if service.Spec.ClusterIP != "None" && service.Spec.ClusterIP != "" {
-			identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", sc.GetInstance().URL, service.Spec.ClusterIP))
+			identifiers = append(identifiers, sc.buildEndpointExternalID(service.Spec.ClusterIP))
 		}
 	case v1.ServiceTypeNodePort:
 		// verify that the node port is not empty
 		if service.Spec.ClusterIP != "None" && service.Spec.ClusterIP != "" {
-			identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", sc.GetInstance().URL, service.Spec.ClusterIP))
+			identifiers = append(identifiers, sc.buildEndpointExternalID(service.Spec.ClusterIP))
 			// map all of the node ports for the ip
 			for _, port := range service.Spec.Ports {
 				// map all the node ports
@@ -158,12 +173,13 @@ func (sc *ServiceCollector) serviceToStackStateComponent(service v1.Service) *to
 	case v1.ServiceTypeLoadBalancer:
 		// verify that the load balance ip is not empty
 		if service.Spec.LoadBalancerIP != "" {
-			identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", sc.GetInstance().URL, service.Spec.LoadBalancerIP))
+			identifiers = append(identifiers, sc.buildEndpointExternalID(service.Spec.LoadBalancerIP))
 		}
 		// verify that the cluster ip is not empty
 		if service.Spec.ClusterIP != "None" && service.Spec.ClusterIP != "" {
-			identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s", sc.GetInstance().URL, service.Spec.ClusterIP))
+			identifiers = append(identifiers, sc.buildEndpointExternalID(service.Spec.ClusterIP))
 		}
+	case v1.ServiceTypeExternalName:
 	default:
 	}
 
@@ -212,6 +228,65 @@ func (sc *ServiceCollector) serviceToStackStateComponent(service v1.Service) *to
 	return component
 }
 
+func (sc *ServiceCollector) serviceToExternalServiceComponent(service v1.Service) *topology.Component {
+	log.Tracef("Mapping kubernetes pod ExternalName service to extra StackState component: %s", service.String())
+	// create identifier list to merge with StackState components
+	identifiers := make([]string, 0)
+
+	if service.Spec.ExternalName != "None" && service.Spec.ExternalName != "" {
+		identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s", service.Spec.ExternalName))
+		// If targetPorts are specified, use those
+		for _, port := range service.Spec.Ports {
+			// map all the node ports
+			if port.Port != 0 {
+				identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s:%d", sc.GetInstance().URL, service.Spec.ExternalName, port.Port))
+			}
+		}
+
+		addrs, err := sc.DNS(service.Spec.ExternalName)
+		if err != nil {
+			log.Warnf("Could not lookup IP addresses for host '%s' (Error: %s)", service.Spec.ExternalName, err.Error())
+		} else {
+			for _, addr := range addrs {
+				identifiers = append(identifiers, sc.buildEndpointExternalID(addr))
+				// If targetPorts are specified, use those
+				for _, port := range service.Spec.Ports {
+					// map all the node ports
+					if port.Port != 0 {
+						identifiers = append(identifiers, fmt.Sprintf("urn:endpoint:/%s:%s:%d", sc.GetInstance().URL, addr, port.Port))
+					}
+				}
+			}
+		}
+	}
+
+	// add identifier for this service name
+	serviceID := buildServiceID(service.Namespace, service.Name)
+	identifiers = append(identifiers, fmt.Sprintf("urn:external-service:/%s:%s", sc.GetInstance().URL, serviceID))
+
+	log.Tracef("Created identifiers for %s: %v", service.Name, identifiers)
+
+	externalID := fmt.Sprintf("%s:%s:external-service/%s", sc.GetURNBuilder().URNPrefix(), service.Namespace, service.Name)
+
+	tags := sc.initTags(service.ObjectMeta)
+
+	component := &topology.Component{
+		ExternalID: externalID,
+		Type:       topology.Type{Name: "external-service"},
+		Data: map[string]interface{}{
+			"name":              service.Name,
+			"creationTimestamp": service.CreationTimestamp,
+			"tags":              tags,
+			"identifiers":       identifiers,
+			"uid":               service.UID,
+		},
+	}
+
+	log.Tracef("Created StackState external-service component %s: %v", externalID, component.JSONString())
+
+	return component
+}
+
 // Creates a StackState relation from a Kubernetes / OpenShift Service to Pod
 func (sc *ServiceCollector) serviceToPodStackStateRelation(serviceExternalID, podExternalID string) *topology.Relation {
 	log.Tracef("Mapping kubernetes pod to service relation: %s -> %s", podExternalID, serviceExternalID)
@@ -230,6 +305,17 @@ func (sc *ServiceCollector) namespaceToServiceStackStateRelation(namespaceExtern
 	relation := sc.CreateRelation(namespaceExternalID, serviceExternalID, "encloses")
 
 	log.Tracef("Created StackState namespace -> service relation %s->%s", relation.SourceID, relation.TargetID)
+
+	return relation
+}
+
+// Creates a StackState relation from a Kubernetes / OpenShift Service to 'ExternalService' relation
+func (sc *ServiceCollector) serviceToExternalServiceStackStateRelation(serviceExternalID, externalServiceExternalID string) *topology.Relation {
+	log.Tracef("Mapping kubernetes service to external service relation: %s -> %s", serviceExternalID, externalServiceExternalID)
+
+	relation := sc.CreateRelation(serviceExternalID, externalServiceExternalID, "uses")
+
+	log.Tracef("Created StackState service -> external service relation %s->%s", relation.SourceID, relation.TargetID)
 
 	return relation
 }

--- a/pkg/collector/corechecks/cluster/topologycollectors/service_collector_test.go
+++ b/pkg/collector/corechecks/cluster/topologycollectors/service_collector_test.go
@@ -51,7 +51,7 @@ func TestServiceCollector(t *testing.T) {
 					Data: topology.Data{
 						"name":              "test-service-1",
 						"creationTimestamp": creationTime,
-						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace"},
+						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "ClusterIP"},
 						"uid":               types.UID("test-service-1"),
 						"identifiers":       []string{"urn:service:/test-cluster-name:test-namespace:test-service-1"},
 					},
@@ -85,7 +85,7 @@ func TestServiceCollector(t *testing.T) {
 					Data: topology.Data{
 						"name":              "test-service-2",
 						"creationTimestamp": creationTime,
-						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace"},
+						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "NodePort"},
 						"uid":               types.UID("test-service-2"),
 						"identifiers": []string{
 							"urn:endpoint:/test-cluster-name:10.100.200.20",
@@ -115,7 +115,7 @@ func TestServiceCollector(t *testing.T) {
 					Data: topology.Data{
 						"name":              "test-service-3",
 						"creationTimestamp": creationTime,
-						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace"},
+						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "ClusterIP"},
 						"uid":               types.UID("test-service-3"),
 						"identifiers": []string{
 							"urn:endpoint:/34.100.200.12:83", "urn:endpoint:/34.100.200.13:83",
@@ -145,7 +145,7 @@ func TestServiceCollector(t *testing.T) {
 					Data: topology.Data{
 						"name":              "test-service-4",
 						"creationTimestamp": creationTime,
-						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace"},
+						"tags":              map[string]string{"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "ClusterIP"},
 						"uid":               types.UID("test-service-4"),
 						"identifiers": []string{
 							"urn:endpoint:/test-cluster-name:10.100.200.22",
@@ -175,7 +175,7 @@ func TestServiceCollector(t *testing.T) {
 						"name":              "test-service-5",
 						"creationTimestamp": creationTime,
 						"tags": map[string]string{
-							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service": "headless",
+							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service": "headless", "service-type": "ClusterIP",
 						},
 						"uid":         types.UID("test-service-5"),
 						"identifiers": []string{"urn:service:/test-cluster-name:test-namespace:test-service-5"},
@@ -203,7 +203,7 @@ func TestServiceCollector(t *testing.T) {
 						"name":              "test-service-6",
 						"creationTimestamp": creationTime,
 						"tags": map[string]string{
-							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace",
+							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "LoadBalancer",
 						},
 						"uid": types.UID("test-service-6"),
 						"identifiers": []string{
@@ -242,7 +242,7 @@ func TestServiceCollector(t *testing.T) {
 						"name":              "test-service-7",
 						"creationTimestamp": creationTime,
 						"tags": map[string]string{
-							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace",
+							"test": "label", "cluster-name": "test-cluster-name", "namespace": "test-namespace", "service-type": "ExternalName",
 						},
 						"uid":         types.UID("test-service-7"),
 						"identifiers": []string{"urn:service:/test-cluster-name:test-namespace:test-service-7"},

--- a/pkg/collector/corechecks/cluster/urn/urn.go
+++ b/pkg/collector/corechecks/cluster/urn/urn.go
@@ -34,6 +34,7 @@ type Builder interface {
 	BuildIngressExternalID(namespace, ingressName string) string
 	BuildVolumeExternalID(namespace, volumeName string) string
 	BuildPersistentVolumeExternalID(persistentVolumeName string) string
+	BuildComponentExternalID(component, namespace, name string) string
 	BuildEndpointExternalID(endpointID string) string
 }
 
@@ -115,72 +116,81 @@ func (b *urnBuilder) BuildNodeExternalID(nodeName string) string {
 
 // BuildPodExternalID creates the urn external identifier for a cluster pod
 func (b *urnBuilder) BuildPodExternalID(namespace, podName string) string {
-	return fmt.Sprintf("%s:%s:pod/%s", b.urnPrefix, namespace, podName)
+	return b.BuildComponentExternalID("pod", namespace, podName)
 }
 
 // BuildContainerExternalID creates the urn external identifier for a pod's container
 func (b *urnBuilder) BuildContainerExternalID(namespace, podName, containerName string) string {
-	return fmt.Sprintf("%s:%s:pod/%s:container/%s", b.urnPrefix, namespace, podName, containerName)
+	return fmt.Sprintf("%s:container/%s", b.BuildPodExternalID(namespace, podName), containerName)
 }
 
 // BuildServiceExternalID creates the urn external identifier for a cluster service
 func (b *urnBuilder) BuildServiceExternalID(namespace, serviceName string) string {
-	return fmt.Sprintf("%s:%s:service/%s", b.urnPrefix, namespace, serviceName)
+	return b.BuildComponentExternalID("service", namespace, serviceName)
 }
 
 // BuildDaemonSetExternalID creates the urn external identifier for a cluster daemon set
 func (b *urnBuilder) BuildDaemonSetExternalID(namespace, daemonSetName string) string {
-	return fmt.Sprintf("%s:%s:daemonset/%s", b.urnPrefix, namespace, daemonSetName)
+	return b.BuildComponentExternalID("daemonset", namespace, daemonSetName)
 }
 
 // BuildDeploymentExternalID creates the urn external identifier for a cluster deployment
 func (b *urnBuilder) BuildDeploymentExternalID(namespace, deploymentName string) string {
-	return fmt.Sprintf("%s:%s:deployment/%s", b.urnPrefix, namespace, deploymentName)
+	return b.BuildComponentExternalID("deployment", namespace, deploymentName)
 }
 
 // BuildReplicaSetExternalID creates the urn external identifier for a cluster replica set
 func (b *urnBuilder) BuildReplicaSetExternalID(namespace, replicaSetName string) string {
-	return fmt.Sprintf("%s:%s:replicaset/%s", b.urnPrefix, namespace, replicaSetName)
+	return b.BuildComponentExternalID("replicaset", namespace, replicaSetName)
 }
 
 // BuildStatefulSetExternalID creates the urn external identifier for a cluster stateful set
 func (b *urnBuilder) BuildStatefulSetExternalID(namespace, statefulSetName string) string {
-	return fmt.Sprintf("%s:%s:statefulset/%s", b.urnPrefix, namespace, statefulSetName)
+	return b.BuildComponentExternalID("statefulset", namespace, statefulSetName)
 }
 
 // BuildConfigMapExternalID creates the urn external identifier for a cluster config map
 func (b *urnBuilder) BuildConfigMapExternalID(namespace, configMapName string) string {
-	return fmt.Sprintf("%s:%s:configmap/%s", b.urnPrefix, namespace, configMapName)
+	return b.BuildComponentExternalID("configmap", namespace, configMapName)
 }
 
 // BuildNamespaceExternalID creates the urn external identifier for a cluster namespace
 func (b *urnBuilder) BuildNamespaceExternalID(namespaceName string) string {
-	return fmt.Sprintf("%s:namespace/%s", b.urnPrefix, namespaceName)
+	return b.BuildComponentExternalID("namespace", "", namespaceName)
 }
 
 // BuildCronJobExternalID creates the urn external identifier for a cluster cron job
 func (b *urnBuilder) BuildCronJobExternalID(namespace, cronJobName string) string {
-	return fmt.Sprintf("%s:%s:cronjob/%s", b.urnPrefix, namespace, cronJobName)
+	return b.BuildComponentExternalID("cronjob", namespace, cronJobName)
 }
 
 // BuildJobExternalID creates the urn external identifier for a cluster job
 func (b *urnBuilder) BuildJobExternalID(namespace, jobName string) string {
-	return fmt.Sprintf("%s:%s:job/%s", b.urnPrefix, namespace, jobName)
+	return b.BuildComponentExternalID("job", namespace, jobName)
 }
 
 // BuildIngressExternalID creates the urn external identifier for a cluster ingress
 func (b *urnBuilder) BuildIngressExternalID(namespace, ingressName string) string {
-	return fmt.Sprintf("%s:%s:ingress/%s", b.urnPrefix, namespace, ingressName)
+	return b.BuildComponentExternalID("ingress", namespace, ingressName)
 }
 
 // BuildVolumeExternalID creates the urn external identifier for a cluster volume
 func (b *urnBuilder) BuildVolumeExternalID(namespace, volumeName string) string {
-	return fmt.Sprintf("%s:%s:volume/%s", b.urnPrefix, namespace, volumeName)
+	return b.BuildComponentExternalID("volume", namespace, volumeName)
 }
 
 // BuildPersistentVolumeExternalID creates the urn external identifier for a cluster persistent volume
 func (b *urnBuilder) BuildPersistentVolumeExternalID(persistentVolumeName string) string {
-	return fmt.Sprintf("%s:persistent-volume/%s", b.urnPrefix, persistentVolumeName)
+	return b.BuildComponentExternalID("persistent-volume", "", persistentVolumeName)
+}
+
+// BuildComponentExternalID creates the urn external identifier for a specific component type
+func (b *urnBuilder) BuildComponentExternalID(component, namespace, name string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s:%s:%s/%s", b.urnPrefix, namespace, component, name)
+	} else {
+		return fmt.Sprintf("%s:%s/%s", b.urnPrefix, component, name)
+	}
 }
 
 // BuildEndpointExternalID

--- a/pkg/collector/corechecks/cluster/urn/urn.go
+++ b/pkg/collector/corechecks/cluster/urn/urn.go
@@ -16,6 +16,7 @@ const (
 
 // Builder builds StackState compatible URNs for Kubernetes components
 type Builder interface {
+	URNPrefix() string
 	BuildExternalID(kind, namespace, objName string) (string, error)
 	BuildClusterExternalID() string
 	BuildConfigMapExternalID(namespace, configMapName string) string
@@ -53,6 +54,11 @@ func NewURNBuilder(clusterType ClusterType, url string) Builder {
 
 func buildURNPrefix(clusterType ClusterType, url string) string {
 	return fmt.Sprintf("urn:%s:/%s", clusterType, url)
+}
+
+// URNPrefix
+func (b *urnBuilder) URNPrefix() string {
+	return b.urnPrefix
 }
 
 func (b *urnBuilder) BuildExternalID(kind, namespace, objName string) (string, error) {

--- a/pkg/collector/corechecks/cluster/urn/urn.go
+++ b/pkg/collector/corechecks/cluster/urn/urn.go
@@ -188,9 +188,9 @@ func (b *urnBuilder) BuildPersistentVolumeExternalID(persistentVolumeName string
 func (b *urnBuilder) BuildComponentExternalID(component, namespace, name string) string {
 	if namespace != "" {
 		return fmt.Sprintf("%s:%s:%s/%s", b.urnPrefix, namespace, component, name)
-	} else {
-		return fmt.Sprintf("%s:%s/%s", b.urnPrefix, component, name)
 	}
+
+	return fmt.Sprintf("%s:%s/%s", b.urnPrefix, component, name)
 }
 
 // BuildEndpointExternalID

--- a/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
+++ b/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
@@ -163,6 +163,23 @@ def test_cluster_agent_base_topology(host, ansible_var):
             cluster_name=cluster_name,
             identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/%s:" % cluster_name))
         )
+        # 1 externalname service with associated external-service component
+        assert _component_data(
+            json_data=json_data,
+            type_name="service",
+            external_id_assert_fn=lambda eid: eid.startswith("urn:kubernetes:/%s:%s:service/"
+                                                             "google-service" % (cluster_name, namespace)),
+            cluster_name=cluster_name,
+            identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/%s:" % cluster_name))
+        )
+        assert _component_data(
+            json_data=json_data,
+            type_name="external-service",
+            external_id_assert_fn=lambda eid: eid.startswith("urn:kubernetes:/%s:%s:external-service/"
+                                                             "google-service" % (cluster_name, namespace)),
+            cluster_name=cluster_name,
+            identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/google.com"))
+        )
         # 1 config map aws-auth
         configmap_match = re.compile("urn:kubernetes:/{}:{}:configmap/aws-auth"
                                      .format(cluster_name, "kube-system"))

--- a/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
+++ b/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
@@ -543,8 +543,8 @@ def test_cluster_agent_base_topology(host, ansible_var):
             external_id_assert_fn=lambda eid: namespace_daemonset_encloses_match.findall(eid)
         ).startswith("urn:kubernetes:/%s:namespace/%s" % (cluster_name, namespace))
         external_name_service_uses_external_match = re.compile("urn:kubernetes:/%s:%s:service/google-service->"
-                                                        "urn:kubernetes:/%s:%s:external-service/google-service" %
-                                                        (cluster_name, namespace, cluster_name, namespace))
+                                                               "urn:kubernetes:/%s:%s:external-service/google-service" %
+                                                               (cluster_name, namespace, cluster_name, namespace))
         assert _relation_data(
             json_data=json_data,
             type_name="uses",

--- a/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
+++ b/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
@@ -172,13 +172,11 @@ def test_cluster_agent_base_topology(host, ansible_var):
             cluster_name=cluster_name,
             identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/%s:" % cluster_name))
         )
-        assert _component_data(
+        assert _find_component(
             json_data=json_data,
             type_name="external-service",
             external_id_assert_fn=lambda eid: eid.startswith("urn:kubernetes:/%s:%s:external-service/"
-                                                             "google-service" % (cluster_name, namespace)),
-            cluster_name=cluster_name,
-            identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/google.com"))
+                                                             "google-service" % (cluster_name, namespace))
         )
         # 1 config map aws-auth
         configmap_match = re.compile("urn:kubernetes:/{}:{}:configmap/aws-auth"

--- a/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
+++ b/test/molecule-role/molecule/kubernetes/tests/test_receiver_topology.py
@@ -164,13 +164,11 @@ def test_cluster_agent_base_topology(host, ansible_var):
             identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/%s:" % cluster_name))
         )
         # 1 externalname service with associated external-service component
-        assert _component_data(
+        assert _find_component(
             json_data=json_data,
             type_name="service",
             external_id_assert_fn=lambda eid: eid.startswith("urn:kubernetes:/%s:%s:service/"
                                                              "google-service" % (cluster_name, namespace)),
-            cluster_name=cluster_name,
-            identifiers_assert_fn=lambda identifiers: next(x for x in identifiers if x.startswith("urn:endpoint:/%s:" % cluster_name))
         )
         assert _find_component(
             json_data=json_data,
@@ -544,5 +542,13 @@ def test_cluster_agent_base_topology(host, ansible_var):
             type_name="encloses",
             external_id_assert_fn=lambda eid: namespace_daemonset_encloses_match.findall(eid)
         ).startswith("urn:kubernetes:/%s:namespace/%s" % (cluster_name, namespace))
+        external_name_service_uses_external_match = re.compile("urn:kubernetes:/%s:%s:service/google-service->"
+                                                        "urn:kubernetes:/%s:%s:external-service/google-service" %
+                                                        (cluster_name, namespace, cluster_name, namespace))
+        assert _relation_data(
+            json_data=json_data,
+            type_name="uses",
+            external_id_assert_fn=lambda eid: external_name_service_uses_external_match.findall(eid)
+        ).startswith("urn:kubernetes:/%s:%s:service/google-service" % (cluster_name, namespace))
 
     util.wait_until(wait_for_cluster_agent_components, 120, 3)


### PR DESCRIPTION
### Step 1: Link to Jira issue
STAC-11523

### Step 2: Description of changes
Add an extra component to the topology if we see a Service with type ExternalName. This component can then be merged in StackState with the actual topology component that is accessed.

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [ ] Integration test
- [ ] E2E/Molecule test


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Did you add release notes describing the changes you made?
- [ ] Yes

### Step 6: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: