### PR TITLE
Stac 11513 windows 2012

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -124,7 +124,7 @@ dependency 'datadog-agent'
 # Additional software
 dependency 'pip'
 dependency 'stackstate-agent-integrations'
-dependency 'datadog-a7'
+#dependency 'datadog-a7'
 dependency 'datadog-agent-env-check'
 dependency 'jmxfetch'
 

--- a/test/molecule-images/Makefile
+++ b/test/molecule-images/Makefile
@@ -1,5 +1,9 @@
 create-win-ami:
 	packer build packer-windows.json
 
+# aws ec2 describe-images --owners amazon --filters "Name=name,Values=Windows_Server-2012-RTM-English-64Bit-Base*" --query 'sort_by(Images, &CreationDate)[].Name'
+create-win12-ami:
+	packer build packer-windows-2012.json
+
 create-receiver-ami:
 	packer build packer-receiver.json

--- a/test/molecule-images/packer-windows-2012.json
+++ b/test/molecule-images/packer-windows-2012.json
@@ -1,0 +1,38 @@
+{
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "region": "eu-west-1",
+            "instance_type": "m3.medium",
+            "source_ami": "ami-0addb9eef1f41128f",
+            "ami_name": "molecule-windows2012-{{timestamp}}",
+            "user_data_file": "winrm_advanced.txt",
+            "communicator": "winrm",
+            "winrm_username": "Administrator",
+            "winrm_password": "Bionic!",
+            "winrm_insecure": true,
+            "winrm_port": "5986",
+            "winrm_use_ssl": true,
+            "tags": {
+                "OS_Version": "Windows 2012",
+                "Team": "Lupulus",
+                "Product": "stackstate-agent-2",
+                "Base_AMI_Name": "{{ .SourceAMIName }}",
+                "Extra": "{{ .SourceAMITags.TagName }}"
+            }
+        }
+    ],
+    "provisioners": [
+        {
+           "type": "ansible",
+           "playbook_file": "./windows_ping.yml",
+           "user": "Administrator",
+           "use_proxy": false,
+           "extra_arguments": [
+             "-vvv",
+             "--extra-vars",
+             "ansible_python_interpreter=auto_silent ansible_shell_type=powershell ansible_shell_executable=None ansible_winrm_server_cert_validation=ignore"
+          ]
+        }
+    ]
+}

--- a/test/molecule-images/packer-windows-2012.json
+++ b/test/molecule-images/packer-windows-2012.json
@@ -33,6 +33,31 @@
              "--extra-vars",
              "ansible_python_interpreter=auto_silent ansible_shell_type=powershell ansible_shell_executable=None ansible_winrm_server_cert_validation=ignore"
           ]
-        }
-    ]
+        },
+      {
+        "type": "windows-restart",
+        "restart_check_command": "powershell -command \"&amp; {Write-Output 'Machine restarted.'}\""
+      },
+      {
+        "type": "powershell",
+        "inline": [
+          "Write-Host 'Starting Defrag C before packing...'",
+          "Get-ChildItem -Path 'C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Log\\' *.log | foreach { Remove-Item -Path $_.FullName }",
+          "Optimize-Volume C -Verbose"
+        ]
+      },
+      {
+        "type": "powershell",
+        "inline": [
+          "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule",
+          "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\SysprepInstance.ps1 -NoShutdown"
+        ]
+      }
+    ],
+  "post-processors": [
+    {
+      "type": "manifest"
+    }
+  ]
+
 }

--- a/test/molecule-images/winrm_advanced_12.txt
+++ b/test/molecule-images/winrm_advanced_12.txt
@@ -1,0 +1,30 @@
+<powershell>
+# Disable Complex Passwords
+# Reference: http://vlasenko.org/2011/04/27/removing-password-complexity-requirements-from-windows-server-2008-core/
+$seccfg = [IO.Path]::GetTempFileName()
+secedit /export /cfg $seccfg
+(Get-Content $seccfg) | Foreach-Object {$_ -replace "PasswordComplexity\s*=\s*1", "PasswordComplexity=0"} | Set-Content $seccfg
+secedit /configure /db $env:windir\security\new.sdb /cfg $seccfg /areas SECURITYPOLICY
+del $seccfg
+Write-Host "Complex Passwords have been disabled." -ForegroundColor Green
+
+$admin = [adsi]("WinNT://./administrator, user")
+$admin.PSBase.Invoke("SetPassword", "Bionic!")
+
+net user test 'Bionic!' /add /y
+net localgroup administrators test /add
+net accounts /maxpwage:unlimited
+
+# Disable Internet Explorer Security
+# http://stackoverflow.com/a/9368555/2067999
+$AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
+$UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
+Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
+Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
+
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/softasap/sa-win/master/bootstrap_light.ps1'))
+
+New-Item c:\provisioned.txt -type file
+
+</powershell>

--- a/test/molecule-role/molecule/vms/create.yml
+++ b/test/molecule-role/molecule/vms/create.yml
@@ -170,6 +170,16 @@
         delay: 10
         timeout: 320
       with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+      when: item.instance != "agent-win"
+
+    - name: Wait for WINRM
+      wait_for:
+        port: "5986"
+        host: "{{ item.address }}"
+        delay: 10
+        timeout: 320
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+      when: item.instance == "agent-win"
 
     - name: Wait for boot process to finish
       pause:

--- a/test/molecule-role/molecule/vms/molecule.yml
+++ b/test/molecule-role/molecule/vms/molecule.yml
@@ -27,7 +27,8 @@ platforms:
     ssh_user: fedora
 
   - name: agent-centos
-    image: ami-0451e9d3427711cb1    # CentOS Linux 6.10 x86_64 HVM EBS ENA 1901_01
+    # image: ami-0451e9d3427711cb1    # CentOS Linux 6.10 x86_64 HVM EBS ENA 1901_01
+    image: ami-04f5641b0d178a27a    # CentOS 7 7.9.2009
     instance_type: t2.micro
     vpc_subnet_id: subnet-fa36adb2  # eu-west-1a
     region: eu-west-1

--- a/test/molecule-role/molecule/vms/molecule.yml
+++ b/test/molecule-role/molecule/vms/molecule.yml
@@ -36,7 +36,8 @@ platforms:
     ssh_user: centos
 
   - name: agent-win
-    image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
+#    image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
+    image: ami-01854c1e9e35eb2ed # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
     instance_type: t3.small
     vpc_subnet_id: subnet-fa36adb2  # eu-west-1a
     region: eu-west-1

--- a/test/molecule-role/molecule/vms/molecule.yml
+++ b/test/molecule-role/molecule/vms/molecule.yml
@@ -37,7 +37,7 @@ platforms:
 
   - name: agent-win
     # image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
-    image: ami-01854c1e9e35eb2ed # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
+    image: ami-01854c1e9e35eb2ed  # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
     instance_type: t3.small
     vpc_subnet_id: subnet-fa36adb2  # eu-west-1a
     region: eu-west-1

--- a/test/molecule-role/molecule/vms/molecule.yml
+++ b/test/molecule-role/molecule/vms/molecule.yml
@@ -36,7 +36,7 @@ platforms:
     ssh_user: centos
 
   - name: agent-win
-#    image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
+    # image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
     image: ami-01854c1e9e35eb2ed # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
     instance_type: t3.small
     vpc_subnet_id: subnet-fa36adb2  # eu-west-1a

--- a/test/molecule-role/molecule/vms/molecule.yml
+++ b/test/molecule-role/molecule/vms/molecule.yml
@@ -37,8 +37,8 @@ platforms:
     ssh_user: centos
 
   - name: agent-win
-    # image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
-    image: ami-01854c1e9e35eb2ed  # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
+    image: ami-044597ab9209135b1  #  Our Packer image based on Windows Server 2016 preconfigured for ansible (EBS-Backed)
+    # image: ami-01854c1e9e35eb2ed  # Our packer image based on Windows Server 2012 preconfigured for ansible (EBS Backed)
     instance_type: t3.small
     vpc_subnet_id: subnet-fa36adb2  # eu-west-1a
     region: eu-west-1

--- a/test/molecule-role/molecule/vms/tests/test_agent_win.py
+++ b/test/molecule-role/molecule/vms/tests/test_agent_win.py
@@ -8,7 +8,7 @@ testinfra_hosts = AnsibleRunner(os.environ["MOLECULE_INVENTORY_FILE"]).get_hosts
 
 def test_stackstate_agent_is_installed(host):
     pkg = "StackState Agent"
-    #res = host.ansible("win_shell", "Get-Package \"{}\"".format(pkg), check=False)
+    # res = host.ansible("win_shell", "Get-Package \"{}\"".format(pkg), check=False)
     res = host.ansible("win_shell", " Get-WmiObject -Class Win32_Product | where name -eq \"{}\" | select Name, Version ".format(pkg), check=False)
     print(res)
     # Name             Version

--- a/test/molecule-role/molecule/vms/tests/test_agent_win.py
+++ b/test/molecule-role/molecule/vms/tests/test_agent_win.py
@@ -8,7 +8,8 @@ testinfra_hosts = AnsibleRunner(os.environ["MOLECULE_INVENTORY_FILE"]).get_hosts
 
 def test_stackstate_agent_is_installed(host):
     pkg = "StackState Agent"
-    res = host.ansible("win_shell", "Get-Package \"{}\"".format(pkg), check=False)
+    #res = host.ansible("win_shell", "Get-Package \"{}\"".format(pkg), check=False)
+    res = host.ansible("win_shell", " Get-WmiObject -Class Win32_Product | where name -eq \"{}\" | select Name, Version ".format(pkg), check=False)
     print(res)
     # Name             Version
     # ----             -------


### PR DESCRIPTION
Adds packer image for windows 2012 (optional,  tests are still on 16)
Molecule tests for windows made compatible with PS3 installed on W12 by default
Due to expiration of centos6, centos tests now based on 7