### PR TITLE
Introduce VSCode Dev Container for developing agent

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,44 @@
+FROM golang:latest
+
+# Configure to avoid build warnings and errors as described in official VSCode Remote-Containers extension documentation.
+# See https://code.visualstudio.com/docs/remote/containers-advanced#_reducing-dockerfile-build-warnings.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+# Verify git, process tools, lsb-release (common in install instructions for CLIs) installed.
+RUN apt-get -y install git iproute2 procps lsb-release
+# Install Python2.7
+RUN apt-get install -y python2.7 python-pip
+
+# Install essential tools for Go development.
+RUN apt-get update \
+    # Install https://github.com/stamblerre/gocode as gocode-gomod (required by VSCode Go extension).
+    && go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && go build -o gocode-gomod github.com/stamblerre/gocode \
+    && mv gocode-gomod $GOPATH/bin/ \
+    # Install other essential Go packages and tools.
+    && go get -u -v \
+    github.com/golang/dep/cmd/dep \
+    golang.org/x/tools/gopls \
+    github.com/mdempsky/gocode \
+    github.com/uudashr/gopkgs/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    golang.org/x/tools/cmd/guru \
+    golang.org/x/tools/cmd/gorename \
+    github.com/go-delve/delve/cmd/dlv \
+    github.com/stamblerre/gocode \
+    github.com/rogpeppe/godef \
+    golang.org/x/tools/cmd/goimports \
+    golang.org/x/lint/golint 2>&1 \
+    # Clean up.
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Revert configurations that was set at top layer (for avoiding build warnings and errors).
+ENV DEBIAN_FRONTEND=dialog
+
+# Expose service ports.
+EXPOSE 8000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "StackState Agent",
+    "dockerFile": "Dockerfile",
+    "extensions": [
+        "golang.go",
+        "ms-python.python",
+        "ms-azuretools.vscode-docker",
+        "eamodio.gitlens",
+        "github.vscode-pull-request-github",
+        "redhat.vscode-yaml",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+    ],
+    "workspaceMount": "src=${localWorkspaceFolder},dst=/go/src/github.com/StackVista/stackstate-agent,type=bind",
+    "workspaceFolder": "/go/src/github.com/StackVista/stackstate-agent",
+    "postCreateCommand": "pip2 install -r requirements.txt",
+    "settings": {
+        "go.buildTags": "kubeapiserver,cpython,kubelet,etcd,docker,zk",
+        "gopls": {
+            "build.buildFlags": [
+                "-tags=kubeapiserver,cpython,kubelet,etcd,docker,zk"
+            ],
+        }
+    }
+}


### PR DESCRIPTION
### Step 1: Link to Jira issue
None

### Step 2: Description of changes
This PR introduces the necessary configuration for running a Dev Container in VSCode for development work on the StackState agent. You will need to run the https://github.com/microsoft/vscode-dev-containers extension in your VSCode. 

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [ ] Integration test
- [ ] E2E/Molecule test


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Did you add release notes describing the changes you made?
- [ ] Yes

### Step 6: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: