### PR TITLE
Fallback to unverified TLS for Kubernetes 1.18+

### DIFF
--- a/cmd/agent/android/app/src/main/assets/datadog.yaml
+++ b/cmd/agent/android/app/src/main/assets/datadog.yaml
@@ -64,6 +64,8 @@ kubelet_client_ca: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 kubelet_client_crt: ""
 kubelet_client_key: ""
 kubelet_tls_verify: true
+kubelet_fallback_to_unverified_tls: true
+kubelet_fallback_to_insecure: true
 kubernetes_collect_service_tags: true
 kubernetes_http_kubelet_port: 10255
 kubernetes_https_kubelet_port: 10250

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,6 +253,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_https_kubelet_port", 10250)
 
 	config.BindEnvAndSetDefault("kubelet_tls_verify", true)
+	config.BindEnvAndSetDefault("kubelet_fallback_to_unverified_tls", true) // sts
+	config.BindEnvAndSetDefault("kubelet_fallback_to_insecure", true)       // sts
 	config.BindEnvAndSetDefault("collect_kubernetes_events", false)
 	config.BindEnvAndSetDefault("collect_kubernetes_metrics", false)
 	config.BindEnvAndSetDefault("collect_kubernetes_topology", true)

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -183,6 +183,8 @@ func (suite *KubeletTestSuite) SetupTest() {
 	mockConfig.Set("kubelet_client_crt", "")
 	mockConfig.Set("kubelet_client_key", "")
 	mockConfig.Set("kubelet_client_ca", "")
+	mockConfig.Set("kubelet_fallback_to_unverified_tls", false)
+	mockConfig.Set("kubelet_fallback_to_insecure", true)
 	mockConfig.Set("kubelet_tls_verify", true)
 	mockConfig.Set("kubelet_auth_token_path", "")
 	mockConfig.Set("kubelet_wait_on_missing_container", 0)

--- a/stackstate-changelog.md
+++ b/stackstate-changelog.md
@@ -9,7 +9,11 @@
   - Added support to map user defined stackstate-domain tags or config to the domain object
   - Added support to map user defined stackstate-identifiers tags or config to the identifiers array
   - Remove `stackstate-identifier`, `stackstate-environment`, `stackstate-layer`, `stackstate-domain` and `stackstate-identifiers` from the tags object if it has been mapped to the data object.
+  - Improved out-of-the-box support for Kubernetes 1.18+ by automatically falling back to using TLS without verifying CA when communicating with the secure Kubelet [(STAC-12205)](https://stackstate.atlassian.net/browse/STAC-12205)
 
+**Bugfix**
+  
+  - Kubelet check should not fail for Kubernetes 1.18+ (due to deprecated `/spec` API endpoint) [(STAC-12307)](https://stackstate.atlassian.net/browse/STAC-12307)
 
 ## 2.10.0 (2021-02-25)
 

--- a/test/integration/util/kubelet/insecurekubelet_test.go
+++ b/test/integration/util/kubelet/insecurekubelet_test.go
@@ -38,6 +38,7 @@ func (suite *InsecureTestSuite) TestHTTP() {
 	mockConfig.Set("kubernetes_https_kubelet_port", 10255)
 	mockConfig.Set("kubelet_auth_token_path", "")
 	mockConfig.Set("kubelet_tls_verify", false)
+	mockConfig.Set("kubelet_fallback_to_insecure", true)
 	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 
 	ku, err := kubelet.GetKubeUtil()
@@ -59,8 +60,26 @@ func (suite *InsecureTestSuite) TestHTTP() {
 
 	require.EqualValues(suite.T(),
 		map[string]string{
-			"url": "http://127.0.0.1:10255",
+			"url":        "http://127.0.0.1:10255",
+			"verify_tls": "false",
 		}, ku.GetRawConnectionInfo())
+}
+
+func (suite *InsecureTestSuite) TestHTTPNotAllowed() {
+	mockConfig := config.Mock()
+
+	mockConfig.Set("kubernetes_http_kubelet_port", 10255)
+
+	// Giving 10255 http port to https setting will force an intended https discovery failure
+	// Then it forces the http usage
+	mockConfig.Set("kubernetes_https_kubelet_port", 10255)
+	mockConfig.Set("kubelet_auth_token_path", "")
+	mockConfig.Set("kubelet_tls_verify", false)
+	mockConfig.Set("kubelet_fallback_to_insecure", false)
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
+
+	_, err := kubelet.GetKubeUtil()
+	require.NotNil(suite.T(), err)
 }
 
 func (suite *InsecureTestSuite) TestInsecureHTTPS() {
@@ -70,6 +89,7 @@ func (suite *InsecureTestSuite) TestInsecureHTTPS() {
 	mockConfig.Set("kubernetes_https_kubelet_port", 10250)
 	mockConfig.Set("kubelet_auth_token_path", "")
 	mockConfig.Set("kubelet_tls_verify", false)
+	mockConfig.Set("kubelet_fallback_to_insecure", true)
 	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 
 	ku, err := kubelet.GetKubeUtil()


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-12205

### Step 2: Description of changes
Automatically fallback to an unverified TLS connection with the possibility to disable this via the configuration or env variable `STS_KUBELET_TLS_FALLBACK_TO_UNVERIFIED`.

In Kubernetes 1.18+ the readonly kubelet port 10255 has been removed, leaving only the TLS secured 10250 port open. Many clusters (kubeadm, kops, AKS) start the Kubelet with its default behavior which is to use a self-signed certificate for that port. This means that our agent cannot connect to the Kubelet anymore, even though it uses the CA file (from the API server) that is made available in its service account secret.

The proper fix would be if all those clusters would configure the Kubelet to use a certificate signed by the API Server CA. Until that is the real world we choose now to have an automatic fallback for the agent to kubelet connection to not verify the validity of the certificate.

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [x] Integration test
- [ ] E2E/Molecule test


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Did you add release notes describing the changes you made?
- [ ] Yes

### Step 6: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: