### PR TITLE
Bumped psutil to 5.8.0 to fix MacOS Big Sur molecule error.

### DIFF
--- a/test/molecule-role/requirements.txt
+++ b/test/molecule-role/requirements.txt
@@ -57,7 +57,7 @@ pexpect==4.6.0
 pluggy==0.9.0
 poyo==0.4.2
 pre-commit==1.20.0
-psutil==5.4.6
+psutil==5.8.0
 ptyprocess==0.6.0
 py==1.8.0
 pyasn1==0.4.5


### PR DESCRIPTION
It was fixed in 5.8.0 psutil release.