### PR TITLE
STAC-0 Change anchore scanning to avoid false negatives caused by cache.

### DIFF
--- a/omnibus/package-scripts/publish_image.sh
+++ b/omnibus/package-scripts/publish_image.sh
@@ -38,7 +38,7 @@ done
 # Comment out the if and fi lines to test anchore scanning on any branch.
 if [ ! -z "${CI_COMMIT_TAG}" ] || [ "${CI_COMMIT_BRANCH}" = "master" ]; then
     # for Anchore use publicly accessible image tag
-    DOCKER_TAG="${REGISTRY_DOCKERHUB}/${ORGANIZATION}/${IMAGE_REPO}:${IMAGE_TAG}"
+    DOCKER_TAG="${REGISTRY_DOCKERHUB}/${ORGANIZATION}/${IMAGE_REPO}:${EXTRA_TAG}"
     echo "Scanning image ${DOCKER_TAG} for vulnerabilities"
     omnibus/package-scripts/anchore-scan.sh -i "${DOCKER_TAG}" -n 0
- fi
+fi


### PR DESCRIPTION
### What does this PR do?

Runs anchor scan against hash container tag instead of "master" or git tag, to ensure a fresh scan and avoid invalid results due to cached layers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
