### PR TITLE
STAC-25461 Drop SLACK_CI_REPORT_CHANNEL from the Cerberus notify path

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -349,4 +349,3 @@ jobs:
       suite: binary-builds
     secrets:
       CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
-      SLACK_CI_REPORT_CHANNEL: ${{ secrets.SLACK_CI_REPORT_CHANNEL }}

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -421,4 +421,3 @@ jobs:
       suite: deb-package
     secrets:
       CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
-      SLACK_CI_REPORT_CHANNEL: ${{ secrets.SLACK_CI_REPORT_CHANNEL }}

--- a/.github/workflows/cerberus-notify.yml
+++ b/.github/workflows/cerberus-notify.yml
@@ -18,14 +18,18 @@ name: Cerberus notify
 # The repo's own .cerberus/cerberus_notify_failure.sh is not reused: it is built
 # around GitLab's CI_* variables and predates the `platform` field.
 #
-# Prerequisite: CERBERUS_LAMBDA_URL and SLACK_CI_REPORT_CHANNEL must reach this repo as
-# REPO-level secrets (StackVista/pulumi-infra PR #258). The org-level copies are
-# visibility=private, which excludes this PUBLIC repo, and widening them is not an option:
-# the Cerberus endpoint is unauthenticated, so the URL is the whole capability. Until #258
-# applies, this workflow warns and exits 0 rather than adding a second red job to an
-# already-failed run -- the annotation is the signal.
+# Prerequisite: CERBERUS_LAMBDA_URL must reach this repo as a REPO-level secret
+# (StackVista/pulumi-infra PR #258). The org-level copy is visibility=private, which
+# excludes this PUBLIC repo, and widening it is not an option: the Cerberus endpoint is
+# unauthenticated, so the URL is the whole capability. Until #258 applies, this workflow
+# warns and exits 0 rather than adding a second red job to an already-failed run -- the
+# annotation is the signal.
 #
-# Both are secrets, so SLACK_CI_REPORT_CHANNEL is read from `secrets`, not `vars`.
+# The Slack channel is deliberately not sent. Cerberus resolves it as
+# `util.GetOrDefault(req.Context, "channel", s.Channel)`, and GetOrDefault treats an empty
+# or whitespace value as absent, so omitting `channel` falls back to the Lambda's own
+# SLACK_CHANNEL. Add a `channel` field to the payload only if agent failures should go
+# somewhere other than the shared CI channel.
 
 on:
   workflow_call:
@@ -35,13 +39,11 @@ on:
         required: true
         type: string
     secrets:
-      # Both are `required: false`. A caller passing `${{ secrets.X }}` for a secret the
-      # repo does not hold yields an empty string, which GitHub rejects as "not provided"
-      # against a required secret and fails the call before the run step's guard can
-      # warn -- the failure mode this workflow exists to avoid.
+      # `required: false`. A caller passing `${{ secrets.X }}` for a secret the repo does
+      # not hold yields an empty string, which GitHub rejects as "not provided" against a
+      # required secret and fails the call before the run step's guard can warn -- the
+      # failure mode this workflow exists to avoid.
       CERBERUS_LAMBDA_URL:
-        required: false
-      SLACK_CI_REPORT_CHANNEL:
         required: false
 
 # Nothing here reads the repository; the payload is built entirely from the
@@ -57,7 +59,6 @@ jobs:
       - name: Post the failure to Cerberus
         env:
           CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
-          SLACK_CHANNEL: ${{ secrets.SLACK_CI_REPORT_CHANNEL }}
           REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
           PIPELINE: ${{ github.run_id }}
@@ -84,7 +85,6 @@ jobs:
               --arg sha "${COMMIT_SHA}" \
               --arg title "${COMMIT_TITLE}" \
               --arg suite "${SUITE}" \
-              --arg channel "${SLACK_CHANNEL}" \
               '{
                 action: "notify",
                 context: {
@@ -96,8 +96,7 @@ jobs:
                   pipeline: $pipeline,
                   "commit.sha": $sha,
                   "commit.title": $title,
-                  suite: $suite,
-                  channel: $channel
+                  suite: $suite
                 }
               }'
             )"

--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -298,4 +298,3 @@ jobs:
       suite: lint-and-unit-tests
     secrets:
       CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
-      SLACK_CI_REPORT_CHANNEL: ${{ secrets.SLACK_CI_REPORT_CHANNEL }}


### PR DESCRIPTION
Removes the Slack channel from the Cerberus notification payload. It was never doing anything, and dropping it halves what pulumi-infra has to provision for this repo.

## Why

@fzhdanov flagged in Slack that `SLACK_CHANNEL_ID` is no longer needed because the Lambda already runs with it. I verified that against the Cerberus source. `internal/router/route/notify.go` resolves the channel as:

```go
Channel: util.GetOrDefault(req.Context, "channel", s.Channel)
```

and `util.GetOrDefault` (`internal/util/context.go:27`) treats an empty **or whitespace** value as absent:

```go
if v, ok := c[key]; ok && strings.TrimSpace(v) != "" {
    return v
}
return defaultValue
```

This repo does not hold `SLACK_CI_REPORT_CHANNEL`, so `${{ secrets.SLACK_CI_REPORT_CHANNEL }}` was expanding to an empty string and every call was already sending `channel: ""` and hitting that fallback. The field was inert.

## What changed

`cerberus-notify.yml`:
- dropped the `SLACK_CI_REPORT_CHANNEL` entry from `workflow_call.secrets`
- dropped the `SLACK_CHANNEL` env var, the `--arg channel` binding, and the `channel:` payload field
- the key is now **omitted** rather than sent empty. `GetOrDefault` makes the two equivalent, but omitting it states the intent
- comment records how to reintroduce it if agent failures should ever go somewhere other than the shared CI channel

The three callers (`lint-and-unit-tests.yml`, `build-binaries.yml`, `build-deb.yml`) no longer pass the secret.

## Knock-on effect

[StackVista/pulumi-infra#258](https://github.com/StackVista/pulumi-infra/pull/258) now asks for a single value, `CERBERUS_LAMBDA_URL`, instead of two. That matters here because org-level secrets default to `visibility: private`, which in GitHub means *private repos only* — and `stackstate-agent` is public, so it cannot see the org-level copies. Fewer repo-level values is a smaller ask and a smaller surface.

## Validation

- `actionlint` — clean apart from the pre-existing unknown-runner-label warnings for our self-hosted labels (`docker-public`, `xlarge-public`, `arm64-xlarge-public`)
- `zizmor --collect=workflows,actions,dependabot .` — `No findings to report`
- the `jq` invocation still emits valid JSON in the shape Cerberus expects:

```json
{"action":"notify","context":{"platform":"github","project.id":"StackVista/stackstate-agent","project.slug":"StackVista/stackstate-agent","project.name":"StackState Agent","branch":"stackstate-7.78.2","pipeline":"123","commit.sha":"abc","commit.title":"STAC-1 fix","suite":"unit-tests"}}
```

No CI behaviour changes: the notify job still only runs on `push` when a needed job failed, and still exits 0 with a warning annotation while `CERBERUS_LAMBDA_URL` is absent.

Targets `STAC-25142-agent-lint-unit` (the #444 integration branch), not `master`.

Jira: https://stackstate.atlassian.net/browse/STAC-25461