### PR TITLE
STAC-24889: authenticate Cerberus calls

### DIFF
--- a/.cerberus/cerberus_notify_failure.sh
+++ b/.cerberus/cerberus_notify_failure.sh
@@ -23,4 +23,12 @@ PAYLOAD=$(cat << END_OF_PAYLOAD
 END_OF_PAYLOAD
 )
 
-curl --verbose --fail --data "${PAYLOAD?Payload is empty}" "${CERBERUS_LAMBDA_URL?No URL Provided}"
+# Suspend xtrace: with `set -x` the expanded curl command - including the bearer
+# token - would be echoed into the job log.
+set +x
+curl --fail --show-error --silent \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer ${CERBERUS_API_TOKEN?No Cerberus API token provided}" \
+  --data "${PAYLOAD?Payload is empty}" \
+  "${CERBERUS_LAMBDA_URL?No URL Provided}"
+set -x


### PR DESCRIPTION
Cerberus now requires CI callers to authenticate with a shared bearer token
(StackVista/cerberus#4) - the endpoint was previously reachable by anyone who knew the URL.

`.cerberus/cerberus_notify_failure.sh` now:
- sends `Authorization: Bearer ${CERBERUS_API_TOKEN}`
- suspends xtrace around the curl and drops `--verbose` - the script runs under
  `set -exuo pipefail`, so either would echo the token into the job log
- uses the `${VAR?message}` form so a missing token fails loudly instead of silently
  sending `Bearer `

Targets `stackstate-7.78.2` because that is the default branch and `.gitlab-ci.yml` pins the
`notify-on-master-fail` job to `only: stackstate-7.78.2` - that is where the live caller is.

The script sends `action: notify` only, so it touches no branch protection.
`CERBERUS_API_TOKEN` is already provisioned for this repo.

Safe to merge before the Cerberus Lambda is redeployed: the current one ignores the header.

Relates to [STAC-24889](https://stackstate.atlassian.net/browse/STAC-24889)