### PR TITLE
STAC-25565 Port the beest verification trigger to GitHub Actions

### DIFF
--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -107,7 +107,7 @@ jobs:
             args+=(--field "agent_branch_under_test=${AGENT_BRANCH}")
             args+=(--field "no_destroy=${NO_DESTROY}")
             if [ -n "${agent_hash}" ]; then
-              args+=(--field "agent_hash_under_test=${agent_hash}")
+              args+=(--field "hashes_under_test=agent=${agent_hash}")
             fi
             if [ -n "${SCENARIOS}" ]; then
               args+=(--field "scenarios=${SCENARIOS}")

--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -155,6 +155,32 @@ jobs:
             *)    echo "::error::unknown suite '${SUITE}'"; exit 1 ;;
           esac
 
+          # beest's scenario choices are architecture-specific and disjoint, so a value that
+          # is valid for one workflow is rejected by the other. Validate every target before
+          # dispatching any of them -- a half-dispatched suite still takes the global beest
+          # AWS lock.
+          scenarios_for() {
+            case "$1" in
+              agent-x86.yml) printf '%s\n' contd-eks-x86-1-36 contd-eks-x86-1-34 contd-eks-x86-1-35-fips all ;;
+              arm.yml)       printf '%s\n' contd-eks-arm-1-36 contd-eks-arm-1-34 all ;;
+            esac
+          }
+
+          if [ -n "${SCENARIOS}" ]; then
+            invalid=0
+            for wf in "${workflows[@]}"; do
+              valid="$(scenarios_for "${wf}")"
+              if ! printf '%s\n' "${valid}" | grep -Fxq "${SCENARIOS}"; then
+                echo "::error::scenario '${SCENARIOS}' is not accepted by ${wf}; valid values: $(printf '%s' "${valid}" | tr '\n' ' ')"
+                invalid=1
+              fi
+            done
+            if [ "${invalid}" -ne 0 ]; then
+              echo "::error::refusing to dispatch suite '${SUITE}' - use a scenario every selected workflow accepts ('all'), or leave it empty for each workflow's own default"
+              exit 1
+            fi
+          fi
+
           {
             echo "## Beest verification dispatched"
             echo
@@ -180,26 +206,43 @@ jobs:
 
             # Snapshot the runs that already exist, because gh does not report the run it
             # queued and every beest AWS workflow shares one global lock -- so the newest
-            # run is routinely somebody else's, or an older queued one.
-            before="$(gh run list --repo StackVista/beest --workflow "${wf}" \
+            # run is routinely somebody else's, or an older queued one. A failure here would
+            # leave the baseline empty and make every existing run look new, so it must not
+            # be swallowed.
+            if ! before="$(gh run list --repo StackVista/beest --workflow "${wf}" \
               --branch "${BEEST_REF}" --limit 100 --json databaseId \
-              --jq '[.[].databaseId | tostring] | join(",")' 2>/dev/null || true)"
+              --jq '[.[].databaseId | tostring] | join(",")')"; then
+              echo "::error::cannot list existing ${wf} runs; refusing to dispatch without a baseline"
+              exit 1
+            fi
 
             echo "dispatching ${wf}"
             gh workflow run "${wf}" "${args[@]}"
 
+            # Link a run only when exactly one new one appeared: a concurrent dispatch of the
+            # same workflow and ref is indistinguishable from this one, and linking the wrong
+            # run sends someone to read unrelated results.
             url=""
+            note=""
             for _ in $(seq 1 30); do
               sleep 5
+              candidates=""
               while read -r id candidate; do
                 case ",${before}," in
                   *",${id},"*) ;;
-                  *) url="${candidate}"; break ;;
+                  *) candidates="${candidates}${candidate}"$'\n' ;;
                 esac
               done < <(gh run list --repo StackVista/beest --workflow "${wf}" \
                 --branch "${BEEST_REF}" --limit 100 --json databaseId,url \
                 --jq '.[] | "\(.databaseId) \(.url)"' 2>/dev/null || true)
-              if [ -n "${url}" ]; then
+
+              count="$(printf '%s' "${candidates}" | grep -c . || true)"
+              if [ "${count}" -eq 1 ]; then
+                url="$(printf '%s' "${candidates}" | head -n 1)"
+                break
+              fi
+              if [ "${count}" -gt 1 ]; then
+                note="${count} new runs appeared, so this dispatch cannot be identified"
                 break
               fi
             done
@@ -208,7 +251,10 @@ jobs:
               echo "${wf} -> ${url}"
               echo "- \`${wf}\` -> ${url}" >> "${GITHUB_STEP_SUMMARY}"
             else
-              echo "::warning::dispatched ${wf} but no new run appeared within 150s"
-              echo "- \`${wf}\` -> https://github.com/StackVista/beest/actions/workflows/${wf} (new run not detected)" >> "${GITHUB_STEP_SUMMARY}"
+              if [ -z "${note}" ]; then
+                note="no new run appeared within 150s"
+              fi
+              echo "::warning::dispatched ${wf} but ${note}"
+              echo "- \`${wf}\` -> https://github.com/StackVista/beest/actions/workflows/${wf} (${note})" >> "${GITHUB_STEP_SUMMARY}"
             fi
           done

--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -1,0 +1,109 @@
+name: Beest verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Which beest agent suite to run (GitLab triggered x86 only)
+        type: choice
+        default: x86
+        options:
+          - x86
+          - arm
+          - both
+      agent_branch_under_test:
+        description: Agent branch beest should deploy (empty = the branch this workflow runs on)
+        type: string
+        default: ""
+      scenarios:
+        description: Beest scenario selector (empty = whatever the beest workflow defaults to)
+        type: string
+        default: ""
+      no_destroy:
+        description: Keep the beest infrastructure after the run (for debugging a failure)
+        type: boolean
+        default: false
+      beest_ref:
+        description: Ref of StackVista/beest to dispatch
+        type: string
+        default: main
+
+permissions: {}
+
+concurrency:
+  group: beest-verification-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    name: Trigger beest agent verification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Mint GitHub App token (dispatch beest workflows)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.BEEST_DISPATCH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BEEST_DISPATCH_APP_PRIVATE_KEY }}
+          owner: StackVista
+          repositories: beest
+          permission-actions: write
+
+      - name: Dispatch beest verification
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SUITE: ${{ inputs.suite }}
+          AGENT_BRANCH: ${{ inputs.agent_branch_under_test || github.ref_name }}
+          AGENT_SHA: ${{ github.sha }}
+          SCENARIOS: ${{ inputs.scenarios }}
+          NO_DESTROY: ${{ inputs.no_destroy }}
+          BEEST_REF: ${{ inputs.beest_ref }}
+        run: |
+          set -euo pipefail
+
+          case "${SUITE}" in
+            x86)  workflows=("agent-x86.yml") ;;
+            arm)  workflows=("arm.yml") ;;
+            both) workflows=("agent-x86.yml" "arm.yml") ;;
+            *)    echo "::error::unknown suite '${SUITE}'"; exit 1 ;;
+          esac
+
+          # beest resolves the agent image from the branch name; the SHA is recorded
+          # for traceability only and is not part of beest's dispatch contract.
+          echo "agent branch under test: ${AGENT_BRANCH} (${AGENT_SHA})"
+
+          {
+            echo "## Beest verification dispatched"
+            echo
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| agent branch under test | \`${AGENT_BRANCH}\` |"
+            echo "| agent commit | \`${AGENT_SHA}\` |"
+            echo "| suite | \`${SUITE}\` |"
+            echo "| scenarios | \`${SCENARIOS:-(beest default)}\` |"
+            echo "| keep infrastructure | \`${NO_DESTROY}\` |"
+            echo "| beest ref | \`${BEEST_REF}\` |"
+            echo
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          for wf in "${workflows[@]}"; do
+            args=(--repo StackVista/beest --ref "${BEEST_REF}")
+            args+=(--field "agent_branch_under_test=${AGENT_BRANCH}")
+            args+=(--field "no_destroy=${NO_DESTROY}")
+            if [ -n "${SCENARIOS}" ]; then
+              args+=(--field "scenarios=${SCENARIOS}")
+            fi
+
+            echo "dispatching ${wf}"
+            gh workflow run "${wf}" "${args[@]}"
+
+            # gh does not report the queued run, and every beest AWS workflow shares
+            # one global lock, so look the run up rather than assuming it started.
+            sleep 10
+            url="$(gh run list --repo StackVista/beest --workflow "${wf}" \
+              --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)"
+            fallback="https://github.com/StackVista/beest/actions/workflows/${wf}"
+            echo "- \`${wf}\` -> ${url:-${fallback}}" >> "${GITHUB_STEP_SUMMARY}"
+          done

--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -15,6 +15,10 @@ on:
         description: Agent branch beest should deploy (empty = the branch this workflow runs on)
         type: string
         default: ""
+      agent_hash_under_test:
+        description: Agent commit beest should pin the image to (empty = the commit this workflow runs on)
+        type: string
+        default: ""
       scenarios:
         description: Beest scenario selector (empty = whatever the beest workflow defaults to)
         type: string
@@ -56,6 +60,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SUITE: ${{ inputs.suite }}
           AGENT_BRANCH: ${{ inputs.agent_branch_under_test || github.ref_name }}
+          AGENT_BRANCH_INPUT: ${{ inputs.agent_branch_under_test }}
+          AGENT_HASH_INPUT: ${{ inputs.agent_hash_under_test }}
           AGENT_SHA: ${{ github.sha }}
           SCENARIOS: ${{ inputs.scenarios }}
           NO_DESTROY: ${{ inputs.no_destroy }}
@@ -70,9 +76,17 @@ jobs:
             *)    echo "::error::unknown suite '${SUITE}'"; exit 1 ;;
           esac
 
-          # beest resolves the agent image from the branch name; the SHA is recorded
-          # for traceability only and is not part of beest's dispatch contract.
-          echo "agent branch under test: ${AGENT_BRANCH} (${AGENT_SHA})"
+          # A branch builds many images, so pin the exact commit rather than letting
+          # beest pick the newest build. Default to this run's SHA, but only when the
+          # branch was not overridden -- against another branch our SHA means nothing,
+          # so leave it unset and let beest fall back.
+          agent_hash="${AGENT_HASH_INPUT}"
+          if [ -z "${agent_hash}" ] && [ -z "${AGENT_BRANCH_INPUT}" ]; then
+            agent_hash="${AGENT_SHA}"
+          fi
+
+          echo "agent branch under test: ${AGENT_BRANCH}"
+          echo "agent commit under test: ${agent_hash:-(unpinned - beest chart default)}"
 
           {
             echo "## Beest verification dispatched"
@@ -80,7 +94,7 @@ jobs:
             echo "| field | value |"
             echo "| --- | --- |"
             echo "| agent branch under test | \`${AGENT_BRANCH}\` |"
-            echo "| agent commit | \`${AGENT_SHA}\` |"
+            echo "| agent commit under test | \`${agent_hash:-(unpinned - beest chart default)}\` |"
             echo "| suite | \`${SUITE}\` |"
             echo "| scenarios | \`${SCENARIOS:-(beest default)}\` |"
             echo "| keep infrastructure | \`${NO_DESTROY}\` |"
@@ -92,6 +106,9 @@ jobs:
             args=(--repo StackVista/beest --ref "${BEEST_REF}")
             args+=(--field "agent_branch_under_test=${AGENT_BRANCH}")
             args+=(--field "no_destroy=${NO_DESTROY}")
+            if [ -n "${agent_hash}" ]; then
+              args+=(--field "agent_hash_under_test=${agent_hash}")
+            fi
             if [ -n "${SCENARIOS}" ]; then
               args+=(--field "scenarios=${SCENARIOS}")
             fi

--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: ""
       agent_hash_under_test:
-        description: Agent commit beest should pin the image to (empty = the commit this workflow runs on)
+        description: Agent commit beest should pin the images to (empty = the tip of the branch under test)
         type: string
         default: ""
       scenarios:
@@ -42,9 +42,90 @@ jobs:
   trigger:
     name: Trigger beest agent verification
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions: {}
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
     steps:
+      - name: Resolve the agent commit under test
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AGENT_BRANCH: ${{ inputs.agent_branch_under_test || github.ref_name }}
+          AGENT_BRANCH_INPUT: ${{ inputs.agent_branch_under_test }}
+          AGENT_HASH_INPUT: ${{ inputs.agent_hash_under_test }}
+          AGENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # beest pins the agent, cluster-agent and checks-agent images to <sha8>-<arch>,
+          # but only when a hash reaches it: resolve-agent-hashes.sh deliberately does not
+          # resolve a branch, so an unset hash silently falls back to the Helm chart default
+          # and the run passes while testing an agent nobody asked for. Always resolve to a
+          # concrete commit -- an overridden branch resolves to its tip.
+          if [ -n "${AGENT_HASH_INPUT}" ]; then
+            ref="${AGENT_HASH_INPUT}"
+          elif [ -n "${AGENT_BRANCH_INPUT}" ]; then
+            ref="${AGENT_BRANCH_INPUT}"
+          else
+            ref="${AGENT_SHA}"
+          fi
+
+          if ! sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${ref}" --jq .sha)"; then
+            echo "::error::cannot resolve '${ref}' to a commit in ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+
+          echo "agent branch under test: ${AGENT_BRANCH}"
+          echo "agent commit under test: ${sha}"
+
+          {
+            echo "agent_branch=${AGENT_BRANCH}"
+            echo "agent_sha=${sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Require published agent images for the commit under test
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AGENT_SHA: ${{ steps.resolve.outputs.agent_sha }}
+        run: |
+          set -euo pipefail
+
+          # In GitLab this job was only playable once both manifest jobs had published.
+          # A standalone dispatch has no such barrier, so without this check it can burn a
+          # full beest run -- and the global beest AWS lock -- on images that were never
+          # pushed, or whose publication failed. Fail closed.
+          required=(
+            "Publish and sign multi-architecture agent image"
+            "Publish and sign multi-architecture cluster-agent image"
+          )
+
+          succeeded="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${AGENT_SHA}&per_page=100" \
+              --jq '.workflow_runs[].id' |
+              while read -r run_id; do
+                gh api --paginate \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" \
+                  --jq '.jobs[] | select(.conclusion == "success") | .name'
+              done
+          )"
+
+          missing=0
+          for job in "${required[@]}"; do
+            if printf '%s\n' "${succeeded}" | grep -Fxq "${job}"; then
+              echo "published: ${job}"
+            else
+              echo "::error::no successful '${job}' for ${AGENT_SHA}; beest would deploy an image that does not exist"
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            echo "::error::agent images for ${AGENT_SHA} are not published - refusing to dispatch beest"
+            exit 1
+          fi
+
       - name: Mint GitHub App token (dispatch beest workflows)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -59,10 +140,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SUITE: ${{ inputs.suite }}
-          AGENT_BRANCH: ${{ inputs.agent_branch_under_test || github.ref_name }}
-          AGENT_BRANCH_INPUT: ${{ inputs.agent_branch_under_test }}
-          AGENT_HASH_INPUT: ${{ inputs.agent_hash_under_test }}
-          AGENT_SHA: ${{ github.sha }}
+          AGENT_BRANCH: ${{ steps.resolve.outputs.agent_branch }}
+          AGENT_HASH: ${{ steps.resolve.outputs.agent_sha }}
           SCENARIOS: ${{ inputs.scenarios }}
           NO_DESTROY: ${{ inputs.no_destroy }}
           BEEST_REF: ${{ inputs.beest_ref }}
@@ -76,25 +155,13 @@ jobs:
             *)    echo "::error::unknown suite '${SUITE}'"; exit 1 ;;
           esac
 
-          # A branch builds many images, so pin the exact commit rather than letting
-          # beest pick the newest build. Default to this run's SHA, but only when the
-          # branch was not overridden -- against another branch our SHA means nothing,
-          # so leave it unset and let beest fall back.
-          agent_hash="${AGENT_HASH_INPUT}"
-          if [ -z "${agent_hash}" ] && [ -z "${AGENT_BRANCH_INPUT}" ]; then
-            agent_hash="${AGENT_SHA}"
-          fi
-
-          echo "agent branch under test: ${AGENT_BRANCH}"
-          echo "agent commit under test: ${agent_hash:-(unpinned - beest chart default)}"
-
           {
             echo "## Beest verification dispatched"
             echo
             echo "| field | value |"
             echo "| --- | --- |"
             echo "| agent branch under test | \`${AGENT_BRANCH}\` |"
-            echo "| agent commit under test | \`${agent_hash:-(unpinned - beest chart default)}\` |"
+            echo "| agent commit under test | \`${AGENT_HASH}\` |"
             echo "| suite | \`${SUITE}\` |"
             echo "| scenarios | \`${SCENARIOS:-(beest default)}\` |"
             echo "| keep infrastructure | \`${NO_DESTROY}\` |"
@@ -105,22 +172,43 @@ jobs:
           for wf in "${workflows[@]}"; do
             args=(--repo StackVista/beest --ref "${BEEST_REF}")
             args+=(--field "agent_branch_under_test=${AGENT_BRANCH}")
+            args+=(--field "hashes_under_test=agent=${AGENT_HASH}")
             args+=(--field "no_destroy=${NO_DESTROY}")
-            if [ -n "${agent_hash}" ]; then
-              args+=(--field "hashes_under_test=agent=${agent_hash}")
-            fi
             if [ -n "${SCENARIOS}" ]; then
               args+=(--field "scenarios=${SCENARIOS}")
             fi
 
+            # Snapshot the runs that already exist, because gh does not report the run it
+            # queued and every beest AWS workflow shares one global lock -- so the newest
+            # run is routinely somebody else's, or an older queued one.
+            before="$(gh run list --repo StackVista/beest --workflow "${wf}" \
+              --branch "${BEEST_REF}" --limit 100 --json databaseId \
+              --jq '[.[].databaseId | tostring] | join(",")' 2>/dev/null || true)"
+
             echo "dispatching ${wf}"
             gh workflow run "${wf}" "${args[@]}"
 
-            # gh does not report the queued run, and every beest AWS workflow shares
-            # one global lock, so look the run up rather than assuming it started.
-            sleep 10
-            url="$(gh run list --repo StackVista/beest --workflow "${wf}" \
-              --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)"
-            fallback="https://github.com/StackVista/beest/actions/workflows/${wf}"
-            echo "- \`${wf}\` -> ${url:-${fallback}}" >> "${GITHUB_STEP_SUMMARY}"
+            url=""
+            for _ in $(seq 1 30); do
+              sleep 5
+              while read -r id candidate; do
+                case ",${before}," in
+                  *",${id},"*) ;;
+                  *) url="${candidate}"; break ;;
+                esac
+              done < <(gh run list --repo StackVista/beest --workflow "${wf}" \
+                --branch "${BEEST_REF}" --limit 100 --json databaseId,url \
+                --jq '.[] | "\(.databaseId) \(.url)"' 2>/dev/null || true)
+              if [ -n "${url}" ]; then
+                break
+              fi
+            done
+
+            if [ -n "${url}" ]; then
+              echo "${wf} -> ${url}"
+              echo "- \`${wf}\` -> ${url}" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "::warning::dispatched ${wf} but no new run appeared within 150s"
+              echo "- \`${wf}\` -> https://github.com/StackVista/beest/actions/workflows/${wf} (new run not detected)" >> "${GITHUB_STEP_SUMMARY}"
+            fi
           done

--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -49,8 +49,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.BEEST_DISPATCH_APP_CLIENT_ID }}
-          private-key: ${{ secrets.BEEST_DISPATCH_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.BEEST_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BEEST_GH_APP_PRIVATE_KEY }}
           owner: StackVista
           repositories: beest
           permission-actions: write


### PR DESCRIPTION
Ports the last unported GitLab job, `beest_trigger_verification`. Every other GitLab job now has a GitHub equivalent.

Manual (`workflow_dispatch`) only, matching the GitLab job, which was `when: manual`. Mints a short-lived App token scoped to `actions: write` on `beest` alone, then dispatches `agent-x86.yml` / `arm.yml`.

**Pins the exact agent commit.** A branch builds many images with different hashes, so sending only the branch would force every run onto whichever build is newest, with no way to verify a specific commit or reproduce a failure against the image that produced it. Defaults to this run's SHA, matching the GitLab job's `CI_COMMIT_SHA`. If `agent_branch_under_test` names a different branch, our SHA does not exist there, so the pin is left unset and beest falls back rather than dispatching a hash that resolves to nothing.

> An earlier revision of this PR sent the branch only and put the SHA in the run summary, claiming beest had no hash input. That was wrong — beest's own GitLab port had dropped the input while keeping all the machinery behind it. **Depends on StackVista/beest#61**, which restores it; until that merges the `agent_hash_under_test` field will be rejected by beest.

**Admin ask (blocking a live run):** needs `BEEST_DISPATCH_APP_CLIENT_ID` (var) and `BEEST_DISPATCH_APP_PRIVATE_KEY` (secret) on this repo, for an App with `actions: write` on `beest`. beest's own credential is repo-level there and not reachable from here.

**Base branch:** `stackstate-7.78.2` rather than the #444 stack. It shares no files or jobs with the build lanes and is manual-only, so it cannot affect any push/PR pipeline and need not queue behind those reviews. Trivial to retarget if preferred.

Dispatch logic tested against a mock `gh` across the pin default, branch-override, explicit-hash, both-suites and invalid-suite paths. actionlint and zizmor clean.