### PR TITLE
STAC-25590 Publish pre-release DEBs to the tooling bucket

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -471,7 +471,7 @@ jobs:
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
           SIGNING_PRIVATE_PASSPHRASE: ${{ secrets.SIGNING_PRIVATE_PASSPHRASE }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-        run: ./omnibus/package-scripts/publish_package.sh stackstate-agent-3-test
+        run: ./omnibus/package-scripts/publish_package.sh sts-agent-prerelease
 
   generate-install-script:
     name: Generate the pre-release agent install script
@@ -494,7 +494,7 @@ jobs:
 
       - name: Render install.sh against the pre-release repositories
         env:
-          STS_AWS_TEST_BUCKET: stackstate-agent-3-test
+          STS_AWS_TEST_BUCKET: sts-agent-prerelease
           STS_AWS_TEST_BUCKET_YUM: stackstate-agent-3-rpm-test
           STS_AWS_TEST_BUCKET_WIN: stackstate-agent-3-test
         run: |
@@ -544,8 +544,8 @@ jobs:
       - name: Upload install.sh
         run: |
           set -euo pipefail
-          aws s3 cp ./install.sh s3://stackstate-agent-3-test/install.sh --acl public-read
-          aws s3 ls s3://stackstate-agent-3-test/
+          aws s3 cp ./install.sh s3://sts-agent-prerelease/install.sh --acl public-read
+          aws s3 ls s3://sts-agent-prerelease/
 
   cerberus-notify:
     name: Report failure to Slack (Cerberus)

--- a/README.md
+++ b/README.md
@@ -105,15 +105,20 @@ To install the official release:
      or
     $ wget -qO- https://stackstate-agent-3.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" bash
 
-##### Test
+##### Pre-release
 
-If you want to install a branch version use the test repository:
+If you want to install a pre-release build use the pre-release repository:
 
-    $ curl -o- https://stackstate-agent-3-test.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="PR_NAME" bash
+    $ curl -fLo- https://sts-agent-prerelease.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="RELEASE_BRANCH" bash
      or
-    $ wget -qO- https://stackstate-agent-3-test.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="PR_NAME" bash
+    $ wget -qO- https://sts-agent-prerelease.s3.amazonaws.com/install.sh | STS_API_KEY="xxx" STS_URL="yyy" CODE_NAME="RELEASE_BRANCH" bash
 
-and replace `PR_NAME` with the branch name (e.g. `master`, `STAC-xxxx`).
+and replace `RELEASE_BRANCH` with the release branch name (e.g. `stackstate-7.78.2`).
+
+Only the release branch is published here: the publishing job runs on pushes to
+that branch and uses the branch name as the apt codename. Per-branch builds such
+as `master` or `STAC-xxxx` are no longer produced — historical ones remain
+readable at `https://stackstate-agent-3-test.s3.amazonaws.com`.
 
 ### Docker
 


### PR DESCRIPTION
The DEB publish lane assumes its OIDC role and signs the package, then gets denied `s3:PutObject`. `stackstate-agent-3-test` lives in the `master` account while the role lives in `tooling`, so the write crosses an account boundary and would need a bucket policy the bucket does not have.

StackVista/terraform-infra#89 creates a tooling-owned replacement, `sts-agent-prerelease`, instead of granting cross-account access to a bucket whose existing policy is what serves the public apt repository. S3 names are global, so it could not keep the old name. It was applied on 17 Aug, so the bucket now exists.

`STS_AWS_TEST_BUCKET_YUM` and `STS_AWS_TEST_BUCKET_WIN` deliberately still point at the `master` buckets — nothing in this lane publishes to them, and that is where their content is. `install.sh` therefore renders a deb URL in tooling and yum/Windows URLs in master until those buckets move too.

The README's per-branch install instructions are corrected to describe what the lane actually publishes. That contract broke at the GitLab-to-Actions port, not here: the publish job is gated on pushes to the release branch and `publish_package.sh` derives the apt codename from the ref, so `master` and `STAC-xxxx` codenames stopped being produced. `dists/master/Release` in the old bucket is unchanged since September 2024 — stale content that made the docs look correct.

### Validation

- `zizmor` clean on the changed workflow
- YAML parses
- The publish itself can only be verified by a push to the release branch, since the job is push-gated

STAC-25590
