### PR TITLE
Move image scans from gate to inform

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -239,11 +239,11 @@ jobs:
             --entrypoint /opt/stackstate-agent/bin/stackstate-cluster-agent/stackstate-cluster-agent \
             "${LOCAL_IMAGE}" version
 
-      - name: Scan cluster-agent image (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
+      - name: Scan cluster-agent image, report-only (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
         uses: StackVista/image-pipeline/.github/actions/scan-image@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
         with:
           image: ${{ env.LOCAL_IMAGE }}
-          mode: gate
+          mode: inform
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           with-grype: true
           exceptions-path: exceptions

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -278,11 +278,11 @@ jobs:
           set -eo pipefail
           docker run --rm --entrypoint /opt/stackstate-agent/bin/agent/agent "${LOCAL_IMAGE}" version
 
-      - name: Scan agent image (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
+      - name: Scan agent image, report-only (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
         uses: StackVista/image-pipeline/.github/actions/scan-image@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
         with:
           image: ${{ env.LOCAL_IMAGE }}
-          mode: gate
+          mode: inform
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           with-grype: true
           exceptions-path: exceptions


### PR DESCRIPTION
Switches the cluster-agent and agent image scans from `mode: gate` to `mode: inform`, per LouisLotter — the intention is not to keep getting stuck on CVEs that a PR did not introduce.

`CVE-2026-73500` is the current example: it turned `stackstate-7.78.2` red overnight and blocked #458, which only touches a beest workflow.

**Kept:** Trivy and Grype still run, VEX and `exceptions/` still apply, and the findings tables and evaluation summary are still printed. Only the exit code changes.

**Given up:** an image with unmanaged HIGH/CRITICAL findings, or expired exceptions, now builds and publishes instead of failing. Remediation pressure moves to the CVE ticket workstream and the scheduled chart scans.

Step names gained `report-only` so a green scan step is not read as a passed gate.

Fixes #487
