### PR TITLE
STAC-25591: repin image-pipeline actions to pick up the Buildx digest fix

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -240,7 +240,7 @@ jobs:
             "${LOCAL_IMAGE}" version
 
       - name: Scan cluster-agent image, report-only (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
-        uses: StackVista/image-pipeline/.github/actions/scan-image@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/scan-image@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: ${{ env.LOCAL_IMAGE }}
           mode: inform
@@ -309,7 +309,7 @@ jobs:
 
       - name: Resolve canonical OCI labels
         id: oci
-        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image-name: stackstate-k8s-cluster-agent
           tag: ${{ steps.image.outputs.tag }}
@@ -322,7 +322,7 @@ jobs:
             [{"registry": "${{ vars.REGISTRY_HOST }}", "username": "${{ vars.REGISTRY_USER }}", "password": "${{ secrets.REGISTRY_PASSWORD }}"}]
 
       - name: Build, publish, and sign architecture image
-        uses: StackVista/image-pipeline/.github/actions/push-single-arch@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/push-single-arch@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: ${{ env.IMAGE }}
           tag: ${{ steps.image.outputs.tag }}
@@ -357,7 +357,7 @@ jobs:
           echo "tag=$(printf '%s' "${SOURCE_SHA}" | cut -c1-8)" >> "${GITHUB_OUTPUT}"
 
       - name: Merge and sign multi-architecture manifest
-        uses: StackVista/image-pipeline/.github/actions/merge-multiarch@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/merge-multiarch@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: quay.io/stackstate/stackstate-k8s-cluster-agent
           tag: ${{ steps.image.outputs.tag }}

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -279,7 +279,7 @@ jobs:
           docker run --rm --entrypoint /opt/stackstate-agent/bin/agent/agent "${LOCAL_IMAGE}" version
 
       - name: Scan agent image, report-only (Trivy and Grype vulnerabilities, VEX-aware, plus Trivy secrets)
-        uses: StackVista/image-pipeline/.github/actions/scan-image@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/scan-image@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: ${{ env.LOCAL_IMAGE }}
           mode: inform
@@ -353,7 +353,7 @@ jobs:
 
       - name: Resolve canonical OCI labels
         id: oci
-        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/apply-oci-labels@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image-name: stackstate-k8s-agent
           tag: ${{ steps.image.outputs.tag }}
@@ -366,7 +366,7 @@ jobs:
             [{"registry": "${{ vars.REGISTRY_HOST }}", "username": "${{ vars.REGISTRY_USER }}", "password": "${{ secrets.REGISTRY_PASSWORD }}"}]
 
       - name: Build, publish, and sign architecture image
-        uses: StackVista/image-pipeline/.github/actions/push-single-arch@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/push-single-arch@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: ${{ env.IMAGE }}
           tag: ${{ steps.image.outputs.tag }}
@@ -404,7 +404,7 @@ jobs:
           echo "tag=$(printf '%s' "${SOURCE_SHA}" | cut -c1-8)" >> "${GITHUB_OUTPUT}"
 
       - name: Merge and sign multi-architecture manifest
-        uses: StackVista/image-pipeline/.github/actions/merge-multiarch@6284a6fc006a7cc46a7f00d02c50d5f21b117b63
+        uses: StackVista/image-pipeline/.github/actions/merge-multiarch@ab8ac3d608530ee0a295483c973d720230174348
         with:
           image: quay.io/stackstate/stackstate-k8s-agent
           tag: ${{ steps.image.outputs.tag }}


### PR DESCRIPTION
Repins the four `image-pipeline` actions in `build-binaries.yml` and `build-deb.yml` onto [image-pipeline#25](https://github.com/StackVista/image-pipeline/pull/25) (`ab8ac3d`).

Every push to this branch has failed in `Publish and sign … image` since ~13 Aug. Our self-hosted runners carry a Buildx built without version ldflags (`v0.0.0+unknown`); `build-push-action` feature-gates its CLI flags on that string, so `--metadata-file` was never passed, `outputs.digest` came back empty, and the verify step built `IMAGE@`. The push itself had already succeeded — so each failure **published an unsigned image** and skipped the multi-arch merge. The same gating dropped `--attest`, so the `sbom`/`provenance` these builds request were never applied.

`pull_request` and `schedule` runs stayed green throughout because the publish jobs are `if: github.event_name == 'push'`, which is why this ran for weeks unnoticed.

Since the publish jobs only run on `push` to the default branch, merging this is also what proves the fix on a self-hosted runner — the pin is so far only verified on GitHub-hosted runners in image-pipeline's own CI.

Tracked in STAC-25591.