### PR TITLE
STAC-25458: run the CI workflows on merge_group

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -2,6 +2,7 @@ name: Binary builds
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - stackstate-7.78.2

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -2,6 +2,7 @@ name: DEB package build
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - stackstate-7.78.2
@@ -191,14 +192,14 @@ jobs:
             --install-directory /opt/stackstate-agent
 
       - name: Save omnibus git cache (${{ matrix.arch }})
-        if: github.event_name != 'pull_request' && steps.omnibus-git-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group' && steps.omnibus-git-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.OMNIBUS_GIT_CACHE_DIR }}
           key: omnibus-git-${{ matrix.arch }}-${{ hashFiles('omnibus/**', 'release.json') }}
 
       - name: Save bazel caches (${{ matrix.arch }})
-        if: github.event_name != 'pull_request' && steps.bazel-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group' && steps.bazel-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -2,6 +2,7 @@ name: Lint and unit tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - stackstate-7.78.2


### PR DESCRIPTION
Adds a `merge_group:` trigger to the three CI workflows, as the prerequisite for enabling a merge queue on the default branch.

The queue requires the `CI success (...)` checks to report on the speculative merge commit, so the workflows must listen on `merge_group` **before** the ruleset is created — otherwise every queued PR waits on checks that never start. The trigger is inert until a queue exists, so this is safe to merge on its own.

Nothing publishes from the queue: publish, sign, Cerberus and the await-verification barrier are all already gated on `event_name == 'push'`. Cache *saves* are excluded from `merge_group` because caches written there are scoped to the throwaway `gh-readonly-queue` ref and could never be restored; restores stay ungated so queue runs still read the default-branch caches.

Validation: all three workflows parse, Zizmor 1.29.0 clean (no findings).

Ref STAC-25458.